### PR TITLE
Mark thread as "daemon"

### DIFF
--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -120,7 +120,7 @@ class HCIdump(Thread):
 
     def __init__(self, dumplist, interface=0, active=0):
         """Initiate HCIdump thread."""
-        Thread.__init__(self)
+        Thread.__init__(self, daemon=True)
         _LOGGER.debug("HCIdump thread: Init")
         self._interface = interface
         self._active = active


### PR DESCRIPTION
Mark thread as "daemon" to help home-assistant better reload