### PR TITLE
Catch key error

### DIFF
--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -528,9 +528,12 @@ class HCIdump(Thread):
                         self._event_loop.run_until_complete(btctrl[hci].stop_scan_request())
                     except RuntimeError as error:
                         _LOGGER.error("HCIdump thread: Runtime error while stop scan request on hci%i: %s", hci, error)
-                    except KeyError as error:
-                        _LOGGER.error("HCIdump thread: Key error while stop scan request on hci%i: %s", hci, error)
-                    conn[hci].close()
+                    except KeyError:
+                        _LOGGER.debug("HCIdump thread: Key error while stop scan request on hci%i", hci)
+                    try:
+                        conn[hci].close()
+                    except KeyError:
+                        _LOGGER.debug("HCIdump thread: Key error while closing connection on hci%i", hci)
                 self._event_loop.run_until_complete(asyncio.sleep(0))
             if self._joining is True:
                 break

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -528,6 +528,8 @@ class HCIdump(Thread):
                         self._event_loop.run_until_complete(btctrl[hci].stop_scan_request())
                     except RuntimeError as error:
                         _LOGGER.error("HCIdump thread: Runtime error while stop scan request on hci%i: %s", hci, error)
+                    except KeyError as error:
+                        _LOGGER.error("HCIdump thread: Key error while stop scan request on hci%i: %s", hci, error)
                     conn[hci].close()
                 self._event_loop.run_until_complete(asyncio.sleep(0))
             if self._joining is True:


### PR DESCRIPTION
Fixes error handling as reported in #203

When multiple hci interfaces are configured, and one of them doesn't work and one does, you will get KeyErrors in the stop of the scanning and closing the hci connection. This PR will catch these KeyErrors. I've chosen for debug level, as there is already an Error in the log, which explains the actual error (that there is no such device on hci#). 



