### PR TITLE
[WIP] Adding decimals setting at device level

### DIFF
--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -26,8 +26,9 @@ from homeassistant.helpers.entity_registry import (
 )
 
 # It was decided to temporarily include this file in the integration bundle
-# until the issue with checking the adapter's capabilities is resolved in the official aioblescan repo
-# see https://github.com/frawau/aioblescan/pull/30, thanks to @vicamo
+# until the issue with checking the adapter's capabilities is resolved in
+# the official aioblescan repo see https://github.com/frawau/aioblescan/pull/30
+# thanks to @vicamo
 from . import aioblescan_ext as aiobs
 
 from .const import (
@@ -42,6 +43,7 @@ from .const import (
     DEFAULT_DISCOVERY,
     DEFAULT_RESTORE_STATE,
     DEFAULT_HCI_INTERFACE,
+    DEFAULT_SENSOR_DECIMALS,
     CONF_ROUNDING,
     CONF_DECIMALS,
     CONF_PERIOD,
@@ -53,6 +55,7 @@ from .const import (
     CONF_REPORT_UNKNOWN,
     CONF_RESTORE_STATE,
     CONF_ENCRYPTION_KEY,
+    CONF_SENSOR_DECIMALS,
     CONFIG_IS_FLOW,
     DOMAIN,
     MAC_REGEX,
@@ -82,6 +85,9 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_ENCRYPTION_KEY): cv.matches_regex(AES128KEY_REGEX),
         vol.Optional(CONF_TEMPERATURE_UNIT): cv.temperature_unit,
+        vol.Optional(
+            CONF_SENSOR_DECIMALS, default=DEFAULT_SENSOR_DECIMALS
+        ): vol.In([DEFAULT_SENSOR_DECIMALS, 0, 1, 2, 3, 4]),
     }
 )
 

--- a/custom_components/ble_monitor/config_flow.py
+++ b/custom_components/ble_monitor/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     DEFAULT_REPORT_UNKNOWN,
     DEFAULT_DISCOVERY,
     DEFAULT_RESTORE_STATE,
+    DEFAULT_SENSOR_DECIMALS,
     CONF_ROUNDING,
     CONF_DECIMALS,
     CONF_PERIOD,
@@ -41,6 +42,7 @@ from .const import (
     CONF_REPORT_UNKNOWN,
     CONF_RESTORE_STATE,
     CONF_ENCRYPTION_KEY,
+    CONF_SENSOR_DECIMALS,
     CONFIG_IS_FLOW,
     DOMAIN,
     MAC_REGEX,
@@ -56,7 +58,12 @@ DEVICE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_MAC, default=""): cv.string,
         vol.Optional(CONF_ENCRYPTION_KEY, default=""): cv.string,
-        vol.Optional(CONF_TEMPERATURE_UNIT, default=TEMP_CELSIUS): vol.In([TEMP_CELSIUS, TEMP_FAHRENHEIT]),
+        vol.Optional(CONF_TEMPERATURE_UNIT, default=TEMP_CELSIUS): vol.In(
+            [TEMP_CELSIUS, TEMP_FAHRENHEIT]
+        ),
+        vol.Optional(CONF_SENSOR_DECIMALS, default=DEFAULT_SENSOR_DECIMALS): vol.In(
+            [DEFAULT_SENSOR_DECIMALS, 0, 1, 2, 3]
+        ),
     }
 )
 
@@ -68,12 +75,8 @@ DOMAIN_SCHEMA = vol.Schema(
         vol.Optional(CONF_PERIOD, default=DEFAULT_PERIOD): cv.positive_int,
         vol.Optional(CONF_DISCOVERY, default=DEFAULT_DISCOVERY): cv.boolean,
         vol.Optional(CONF_ACTIVE_SCAN, default=DEFAULT_ACTIVE_SCAN): cv.boolean,
-        vol.Optional(
-            CONF_REPORT_UNKNOWN, default=DEFAULT_REPORT_UNKNOWN
-        ): cv.boolean,
-        vol.Optional(
-            CONF_BATT_ENTITIES, default=DEFAULT_BATT_ENTITIES
-        ): cv.boolean,
+        vol.Optional(CONF_REPORT_UNKNOWN, default=DEFAULT_REPORT_UNKNOWN): cv.boolean,
+        vol.Optional(CONF_BATT_ENTITIES, default=DEFAULT_BATT_ENTITIES): cv.boolean,
         vol.Optional(CONF_ROUNDING, default=DEFAULT_ROUNDING): cv.boolean,
         vol.Optional(CONF_DECIMALS, default=DEFAULT_DECIMALS): cv.positive_int,
         vol.Optional(CONF_LOG_SPIKES, default=DEFAULT_LOG_SPIKES): cv.boolean,
@@ -90,6 +93,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class BLEMonitorFlow(data_entry_flow.FlowHandler):
     """BLEMonitor flow"""
+
     def __init__(self):
         """Initialize flow instance."""
         self._devices = {}
@@ -100,7 +104,6 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
         compiled = re.compile(regex)
         if not compiled.match(value):
             return False
-
         return True
 
     def validate_mac(self, value: str, errors: list):
@@ -112,7 +115,6 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
         """key validation"""
         if not value or value == "-":
             return
-
         if not self.validate_regex(value, AES128KEY_REGEX):
             errors[CONF_ENCRYPTION_KEY] = "invalid_key"
 
@@ -124,10 +126,11 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
 
         uinput[CONF_DEVICES] = []
         for _, dev in self._devices.items():
-            if CONF_ENCRYPTION_KEY in dev and (not dev[CONF_ENCRYPTION_KEY] or dev[CONF_ENCRYPTION_KEY] == "-"):
+            if CONF_ENCRYPTION_KEY in dev and (
+                not dev[CONF_ENCRYPTION_KEY] or dev[CONF_ENCRYPTION_KEY] == "-"
+            ):
                 del dev[CONF_ENCRYPTION_KEY]
             uinput[CONF_DEVICES].append(dev)
-
         return self.async_create_entry(title=DOMAIN_TITLE, data=uinput)
 
     @callback
@@ -136,11 +139,19 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
         option_devices[OPTION_LIST_DEVICE] = OPTION_LIST_DEVICE
         option_devices[OPTION_ADD_DEVICE] = OPTION_ADD_DEVICE
         for _, device in self._devices.items():
-            name = device.get(CONF_NAME) if device.get(CONF_NAME) else device.get(CONF_MAC).upper()
+            name = (
+                device.get(CONF_NAME)
+                if device.get(CONF_NAME)
+                else device.get(CONF_MAC).upper()
+            )
             option_devices[device.get(CONF_MAC).upper()] = name
-        config_schema = schema.extend({
-            vol.Optional(CONF_DEVICES, default=OPTION_LIST_DEVICE): vol.In(option_devices),
-        })
+        config_schema = schema.extend(
+            {
+                vol.Optional(CONF_DEVICES, default=OPTION_LIST_DEVICE): vol.In(
+                    option_devices
+                ),
+            }
+        )
         return self.async_show_form(
             step_id=step_id, data_schema=config_schema, errors=errors or {}
         )
@@ -151,27 +162,42 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
         if user_input is not None:
             _LOGGER.debug("async_step_add_device: %s", user_input)
             if user_input[CONF_MAC] and user_input[CONF_MAC] != "-":
-                if self._sel_device and user_input[CONF_MAC].upper() != self._sel_device.get(CONF_MAC).upper():
+                if (
+                    self._sel_device
+                    and user_input[CONF_MAC].upper()
+                    != self._sel_device.get(CONF_MAC).upper()
+                ):
                     errors[CONF_MAC] = "cannot_change_mac"
                     user_input[CONF_MAC] = self._sel_device.get(CONF_MAC)
                 else:
                     self.validate_mac(user_input[CONF_MAC], errors)
                     self.validate_key(user_input[CONF_ENCRYPTION_KEY], errors)
-
                 if not errors:
                     # updating device configuration instead of overwriting
                     try:
-                        self._devices[user_input["mac"].upper()].update(copy.deepcopy(user_input))  # copy.deepcopy(user_input)
+                        self._devices[user_input["mac"].upper()].update(
+                            copy.deepcopy(user_input)
+                        )
                     except KeyError:
-                        self._devices.update({user_input["mac"].upper(): copy.deepcopy(user_input)})
+                        self._devices.update(
+                            {user_input["mac"].upper(): copy.deepcopy(user_input)}
+                        )
                     self._sel_device = {}  # prevent deletion
-
             if errors:
                 retry_device_option_schema = vol.Schema(
                     {
                         vol.Optional(CONF_MAC, default=user_input[CONF_MAC]): str,
-                        vol.Optional(CONF_ENCRYPTION_KEY, default=user_input[CONF_ENCRYPTION_KEY]): str,
-                        vol.Optional(CONF_TEMPERATURE_UNIT, default=user_input[CONF_TEMPERATURE_UNIT]): vol.In([TEMP_CELSIUS, TEMP_FAHRENHEIT]),
+                        vol.Optional(
+                            CONF_ENCRYPTION_KEY, default=user_input[CONF_ENCRYPTION_KEY]
+                        ): str,
+                        vol.Optional(
+                            CONF_TEMPERATURE_UNIT,
+                            default=user_input[CONF_TEMPERATURE_UNIT],
+                        ): vol.In([TEMP_CELSIUS, TEMP_FAHRENHEIT]),
+                        vol.Optional(
+                            CONF_SENSOR_DECIMALS,
+                            default=user_input[CONF_SENSOR_DECIMALS],
+                        ): vol.In([DEFAULT_SENSOR_DECIMALS, 0, 1, 2, 3]),
                     }
                 )
                 return self.async_show_form(
@@ -179,17 +205,35 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
                     data_schema=retry_device_option_schema,
                     errors=errors,
                 )
-
-            if (self._sel_device):
+            if self._sel_device:
                 del self._devices[self._sel_device.get(CONF_MAC).upper()]
-
             return self._show_main_form(errors)
-
         device_option_schema = vol.Schema(
             {
-                vol.Optional(CONF_MAC, default=self._sel_device.get(CONF_MAC) if self._sel_device.get(CONF_MAC) else ""): str,
-                vol.Optional(CONF_ENCRYPTION_KEY, default=self._sel_device.get(CONF_ENCRYPTION_KEY) if self._sel_device.get(CONF_ENCRYPTION_KEY) else ""): str,
-                vol.Optional(CONF_TEMPERATURE_UNIT, default=self._sel_device.get(CONF_TEMPERATURE_UNIT) if self._sel_device.get(CONF_TEMPERATURE_UNIT) else TEMP_CELSIUS): vol.In([TEMP_CELSIUS, TEMP_FAHRENHEIT]),
+                vol.Optional(
+                    CONF_MAC,
+                    default=self._sel_device.get(CONF_MAC)
+                    if self._sel_device.get(CONF_MAC)
+                    else "",
+                ): str,
+                vol.Optional(
+                    CONF_ENCRYPTION_KEY,
+                    default=self._sel_device.get(CONF_ENCRYPTION_KEY)
+                    if self._sel_device.get(CONF_ENCRYPTION_KEY)
+                    else "",
+                ): str,
+                vol.Optional(
+                    CONF_TEMPERATURE_UNIT,
+                    default=self._sel_device.get(CONF_TEMPERATURE_UNIT)
+                    if self._sel_device.get(CONF_TEMPERATURE_UNIT)
+                    else TEMP_CELSIUS,
+                ): vol.In([TEMP_CELSIUS, TEMP_FAHRENHEIT]),
+                vol.Optional(
+                    CONF_SENSOR_DECIMALS,
+                    default=self._sel_device.get(CONF_SENSOR_DECIMALS)
+                    if self._sel_device.get(CONF_SENSOR_DECIMALS)
+                    else DEFAULT_SENSOR_DECIMALS,
+                ): vol.In([DEFAULT_SENSOR_DECIMALS, 0, 1, 2, 3]),
             }
         )
 
@@ -202,6 +246,7 @@ class BLEMonitorFlow(data_entry_flow.FlowHandler):
 
 class BLEMonitorConfigFlow(BLEMonitorFlow, config_entries.ConfigFlow, domain=DOMAIN):
     """BLEMonitor config flow"""
+
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
@@ -222,7 +267,6 @@ class BLEMonitorConfigFlow(BLEMonitorFlow, config_entries.ConfigFlow, domain=DOM
             return self.async_abort(reason="single_instance_allowed")
         if self.hass.data.get(DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
             if CONF_DEVICES not in user_input:
                 user_input[CONF_DEVICES] = {}
@@ -232,12 +276,10 @@ class BLEMonitorConfigFlow(BLEMonitorFlow, config_entries.ConfigFlow, domain=DOM
             if user_input[CONF_DEVICES] in self._devices:
                 self._sel_device = self._devices[user_input[CONF_DEVICES]]
                 return await self.async_step_add_device()
-
             await self.async_set_unique_id(DOMAIN_TITLE)
             self._abort_if_unique_id_configured()
 
             return self._create_entry(user_input)
-
         return self._show_main_form(errors)
 
     async def async_step_import(self, user_input=None):
@@ -260,22 +302,69 @@ class BLEMonitorOptionsFlow(BLEMonitorFlow, config_entries.OptionsFlow):
         options_schema = vol.Schema(
             {
                 vol.Optional(
-                    CONF_HCI_INTERFACE, default=self.config_entry.options.get(CONF_HCI_INTERFACE, DEFAULT_HCI_INTERFACE)
+                    CONF_HCI_INTERFACE,
+                    default=self.config_entry.options.get(
+                        CONF_HCI_INTERFACE, DEFAULT_HCI_INTERFACE
+                    ),
                 ): cv.multi_select({"0": "0", "1": "1", "2": "2"}),
-                vol.Optional(CONF_PERIOD, default=self.config_entry.options.get(CONF_PERIOD, DEFAULT_PERIOD)): cv.positive_int,
-                vol.Optional(CONF_DISCOVERY, default=self.config_entry.options.get(CONF_DISCOVERY, DEFAULT_DISCOVERY)): cv.boolean,
-                vol.Optional(CONF_ACTIVE_SCAN, default=self.config_entry.options.get(CONF_ACTIVE_SCAN, DEFAULT_ACTIVE_SCAN)): cv.boolean,
                 vol.Optional(
-                    CONF_REPORT_UNKNOWN, default=self.config_entry.options.get(CONF_REPORT_UNKNOWN, DEFAULT_REPORT_UNKNOWN)
+                    CONF_PERIOD,
+                    default=self.config_entry.options.get(CONF_PERIOD, DEFAULT_PERIOD),
+                ): cv.positive_int,
+                vol.Optional(
+                    CONF_DISCOVERY,
+                    default=self.config_entry.options.get(
+                        CONF_DISCOVERY, DEFAULT_DISCOVERY
+                    ),
                 ): cv.boolean,
                 vol.Optional(
-                    CONF_BATT_ENTITIES, default=self.config_entry.options.get(CONF_BATT_ENTITIES, DEFAULT_BATT_ENTITIES)
+                    CONF_ACTIVE_SCAN,
+                    default=self.config_entry.options.get(
+                        CONF_ACTIVE_SCAN, DEFAULT_ACTIVE_SCAN
+                    ),
                 ): cv.boolean,
-                vol.Optional(CONF_ROUNDING, default=self.config_entry.options.get(CONF_ROUNDING, DEFAULT_ROUNDING)): cv.boolean,
-                vol.Optional(CONF_DECIMALS, default=self.config_entry.options.get(CONF_DECIMALS, DEFAULT_DECIMALS)): cv.positive_int,
-                vol.Optional(CONF_LOG_SPIKES, default=self.config_entry.options.get(CONF_LOG_SPIKES, DEFAULT_LOG_SPIKES)): cv.boolean,
-                vol.Optional(CONF_USE_MEDIAN, default=self.config_entry.options.get(CONF_USE_MEDIAN, DEFAULT_USE_MEDIAN)): cv.boolean,
-                vol.Optional(CONF_RESTORE_STATE, default=self.config_entry.options.get(CONF_RESTORE_STATE, DEFAULT_RESTORE_STATE)): cv.boolean,
+                vol.Optional(
+                    CONF_REPORT_UNKNOWN,
+                    default=self.config_entry.options.get(
+                        CONF_REPORT_UNKNOWN, DEFAULT_REPORT_UNKNOWN
+                    ),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_BATT_ENTITIES,
+                    default=self.config_entry.options.get(
+                        CONF_BATT_ENTITIES, DEFAULT_BATT_ENTITIES
+                    ),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_ROUNDING,
+                    default=self.config_entry.options.get(
+                        CONF_ROUNDING, DEFAULT_ROUNDING
+                    ),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_DECIMALS,
+                    default=self.config_entry.options.get(
+                        CONF_DECIMALS, DEFAULT_DECIMALS
+                    ),
+                ): cv.positive_int,
+                vol.Optional(
+                    CONF_LOG_SPIKES,
+                    default=self.config_entry.options.get(
+                        CONF_LOG_SPIKES, DEFAULT_LOG_SPIKES
+                    ),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_USE_MEDIAN,
+                    default=self.config_entry.options.get(
+                        CONF_USE_MEDIAN, DEFAULT_USE_MEDIAN
+                    ),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_RESTORE_STATE,
+                    default=self.config_entry.options.get(
+                        CONF_RESTORE_STATE, DEFAULT_RESTORE_STATE
+                    ),
+                ): cv.boolean,
             }
         )
         return self._show_user_form("init", options_schema, errors or {})
@@ -288,31 +377,34 @@ class BLEMonitorOptionsFlow(BLEMonitorFlow, config_entries.OptionsFlow):
 
         if user_input is not None:
             _LOGGER.debug("async_step_init (after): %s", user_input)
-            if CONFIG_IS_FLOW in self.config_entry.options and not self.config_entry.options[CONFIG_IS_FLOW]:
+            if (
+                CONFIG_IS_FLOW in self.config_entry.options
+                and not self.config_entry.options[CONFIG_IS_FLOW]
+            ):
                 return self.async_abort(reason="not_in_use")
-
             if user_input[CONF_DEVICES] == OPTION_ADD_DEVICE:
                 self._sel_device = {}
                 return await self.async_step_add_device()
             if user_input[CONF_DEVICES] in self._devices:
                 self._sel_device = self._devices[user_input[CONF_DEVICES]]
                 return await self.async_step_add_device()
-
             return self._create_entry(user_input)
-
         _LOGGER.debug("async_step_init (before): %s", self.config_entry.options)
 
-        if CONFIG_IS_FLOW in self.config_entry.options and not self.config_entry.options[CONFIG_IS_FLOW]:
+        if (
+            CONFIG_IS_FLOW in self.config_entry.options
+            and not self.config_entry.options[CONFIG_IS_FLOW]
+        ):
             options_schema = vol.Schema({vol.Optional("not_in_use", default=""): str})
             return self.async_show_form(
                 step_id="init", data_schema=options_schema, errors=errors or {}
             )
-
         for dev in self.config_entry.options.get(CONF_DEVICES):
             self._devices[dev[CONF_MAC].upper()] = dev
-
         devreg = await self.hass.helpers.device_registry.async_get_registry()
-        for dev in device_registry.async_entries_for_config_entry(devreg, self.config_entry.entry_id):
+        for dev in device_registry.async_entries_for_config_entry(
+            devreg, self.config_entry.entry_id
+        ):
             for iddomain, idmac in dev.identifiers:
                 if iddomain != DOMAIN:
                     continue
@@ -321,12 +413,12 @@ class BLEMonitorOptionsFlow(BLEMonitorFlow, config_entries.OptionsFlow):
                     self._devices[idmac][CONF_NAME] = name
                 else:
                     self._devices[idmac] = {CONF_MAC: idmac, CONF_NAME: name}
-
         # sort devices by name
-        sorteddev_tuples = sorted(self._devices.items(), key=lambda item: item[1].get("name", item[1]["mac"]))
+        sorteddev_tuples = sorted(
+            self._devices.items(), key=lambda item: item[1].get("name", item[1]["mac"])
+        )
         self._devices = dict(sorteddev_tuples)
         self.hass.config_entries.async_update_entry(
-            self.config_entry,
-            unique_id=self.config_entry.entry_id
+            self.config_entry, unique_id=self.config_entry.entry_id
         )
         return self._show_main_form(errors)

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -14,6 +14,7 @@ CONF_BATT_ENTITIES = "batt_entities"
 CONF_REPORT_UNKNOWN = "report_unknown"
 CONF_RESTORE_STATE = "restore_state"
 CONF_ENCRYPTION_KEY = "encryption_key"
+CONF_SENSOR_DECIMALS = "decimals"
 CONFIG_IS_FLOW = "is_flow"
 
 SERVICE_CLEANUP_ENTRIES = "cleanup_entries"
@@ -30,6 +31,7 @@ DEFAULT_BATT_ENTITIES = False
 DEFAULT_REPORT_UNKNOWN = False
 DEFAULT_DISCOVERY = True
 DEFAULT_RESTORE_STATE = False
+DEFAULT_SENSOR_DECIMALS = "default"
 
 # regex constants for configuration schema
 MAC_REGEX = "(?i)^(?:[0-9A-F]{2}[:]){5}(?:[0-9A-F]{2})$"

--- a/custom_components/ble_monitor/strings.json
+++ b/custom_components/ble_monitor/strings.json
@@ -9,7 +9,7 @@
           "devices": "Devices",
           "discovery": "Discovery",
           "rounding": "Rounding",
-          "decimals": "Decimals",
+          "decimals": "Number of decimals",
           "period": "Period",
           "log_spikes": "Log spikes",
           "use_median": "Use median",
@@ -23,8 +23,9 @@
         "title": "Add device",
         "data": {
           "mac": "MAC address",
-          "temperature_unit": "Temperature unit",
-          "encryption_key": "Encryption key"
+          "encryption_key": "Encryption key",
+          "decimals": "Number of decimals (rounding must be enabled)",
+          "temperature_unit": "Temperature unit"
         }
       }  
     },
@@ -47,7 +48,7 @@
           "devices": "Devices",
           "discovery": "Discovery",
           "rounding": "Rounding",
-          "decimals": "Decimals",
+          "decimals": "Number of decimals",
           "period": "Period",
           "log_spikes": "Log spikes",
           "use_median": "Use median",
@@ -62,8 +63,9 @@
         "title": "Configure device",
         "data": {
           "mac": "MAC address (set to '-' to delete)",
-          "temperature_unit": "Temperature unit",
-          "encryption_key": "Encryption key (set to '-' to remove)"
+          "encryption_key": "Encryption key (set to '-' to remove)",
+          "decimals": "Number of decimals (rounding must be enabled)",
+          "temperature_unit": "Temperature unit"
         }
       }  
     },

--- a/custom_components/ble_monitor/translations/en.json
+++ b/custom_components/ble_monitor/translations/en.json
@@ -9,7 +9,7 @@
           "devices": "Devices",
           "discovery": "Discovery",
           "rounding": "Rounding",
-          "decimals": "Decimals",
+          "decimals": "Number of decimals",
           "period": "Period",
           "log_spikes": "Log spikes",
           "use_median": "Use median",
@@ -23,8 +23,9 @@
         "title": "Add device",
         "data": {
           "mac": "MAC address",
-          "temperature_unit": "Temperature unit",
-          "encryption_key": "Encryption key"
+          "encryption_key": "Encryption key",
+          "decimals": "Number of decimals (rounding must be enabled)",
+          "temperature_unit": "Temperature unit"
         }
       }  
     },
@@ -47,7 +48,7 @@
           "devices": "Devices",
           "discovery": "Discovery",
           "rounding": "Rounding",
-          "decimals": "Decimals",
+          "decimals": "Number of decimals",
           "period": "Period",
           "log_spikes": "Log spikes",
           "use_median": "Use median",
@@ -62,8 +63,9 @@
         "title": "Configure device",
         "data": {
           "mac": "MAC address (set to '-' to delete)",
-          "temperature_unit": "Temperature unit",
-          "encryption_key": "Encryption key (set to '-' to remove)"
+          "encryption_key": "Encryption key (set to '-' to remove)",
+          "decimals": "Number of decimals (rounding must be enabled)",
+          "temperature_unit": "Temperature unit"
         }
       }  
     },


### PR DESCRIPTION
This PR adds a decimals setting at device level, that can overrule the integration setting for individual sensors. Default value is default, which means that it will use the integration setting.

![image](https://user-images.githubusercontent.com/24375847/102891602-c3f28e80-445e-11eb-8555-203a509cb02d.png)

Other changes:

- sensorname is renamed to device_name for example get_sensorname is renamed to get_device_name as this fits better with the naming of HA.
- Some commented out code is removed
- Applied black on parts of the code to clean it up a little bit.

Note. I moved the repository to here (`decimals-at-device-level` branch). I made in [WIP], will try to add/change the following. 

- [ ] Remove `rounding` option