### PR TITLE
revert NoValidError for sensor not in whitelist

### DIFF
--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -722,7 +722,7 @@ class HCIdump(Thread):
 
         # check for MAC presence in whitelist, if needed
         if self.discovery is False and xiaomi_mac_reversed not in self.whitelist:
-            raise NoValidError("MAC is not present in whitelist")
+            return None, None, None
         packet_id = data[xiaomi_index + 7]
         try:
             prev_packet = self.lpacket_ids[xiaomi_mac_reversed]
@@ -925,7 +925,7 @@ class HCIdump(Thread):
 
         # check for MAC presence in whitelist, if needed
         if self.discovery is False and qingping_mac_reversed not in self.whitelist:
-            raise NoValidError("MAC is not present in whitelist")
+            return None, None, None
         packet_id = "no packed id"
 
         # extract RSSI byte
@@ -1041,7 +1041,7 @@ class HCIdump(Thread):
 
         # check for MAC presence in whitelist, if needed
         if self.discovery is False and source_mac_reversed not in self.whitelist:
-            raise NoValidError("MAC is not present in whitelist")
+            return None, None, None
 
         packet_id = data[atc_index + 16 if is_custom_adv else atc_index + 15]
         try:

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -446,8 +446,11 @@ class HCIdump(Thread):
             return {"battery": xobj[0]}
 
         def obj0d10(xobj):
-            (temp, humi) = TH_STRUCT.unpack(xobj)
-            return {"temperature": temp / 10, "humidity": humi / 10}
+            if len(xobj) == 4:
+                (temp, humi) = TH_STRUCT.unpack(xobj)
+                return {"temperature": temp / 10, "humidity": humi / 10}
+            else:
+                return {}
 
         def obj0020(xobj):
             (temp1, temp2, bat) = TTB_STRUCT.unpack(xobj)

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -801,7 +801,7 @@ class HCIdump(Thread):
                 key = self.aeskeys[xiaomi_mac_reversed]
             except KeyError:
                 # no encryption key found
-                raise NoValidError("No encription key found")
+                raise NoValidError("No encryption key found")
             nonce = b"".join(
                 [
                     xiaomi_mac_reversed,


### PR DESCRIPTION
Reverted the error that was raised when a device is not in the whitelist and discovery is set to false. 

@SeiTaN This is not an error, but an intentional configuration by the user. So I reverted the error handling for this specific occasion. 

Fixes #293 