### PR TITLE
ATC v2.9 support

### DIFF
--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -9,5 +9,5 @@
     "@Magalex2x14",
     "@Ernst79"
   ],
-  "version": "1.3.1"
+  "version": "1.4.0"
 }

--- a/info.md
+++ b/info.md
@@ -12,9 +12,9 @@
 {% endif %}
 {% if installed or pending_update %}
 
-# Changes in 1.3.1
+# Changes in 1.4.0
 
-- Fix for Qingping CGPR1 Motion & Ambient Light Sensor (fix for #306)
+- Add support for ATC firmware v2.9 and above. 
 
 {% endif %}
 


### PR DESCRIPTION
Add support for ATC v2.9 firmware. 

ATC v2.9 adds `02 01 06` to the advertisements. 