### PR TITLE
Add Quingping CGG1 variant

### DIFF
--- a/custom_components/ble_monitor/ble_parser/qingping.py
+++ b/custom_components/ble_monitor/ble_parser/qingping.py
@@ -8,6 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 # {device type code: (device name, binary?)}
 QINGPING_TYPE_DICT = {
     b'\x08\x07': ("CGG1", False),
+    b'\x08\x01': ("CGG1", False),
     b'\x08\x09': ("CGP1W", False),
     b'\x08\x0C': ("CGD1", False),
 }


### PR DESCRIPTION
Added another device type header for my CGG1's. And magically they showed up after a year of struggle.

My devices have no Quingping logo on the back and they don't work with Mi Home app. They only work with the Quingping app.

FCCID: 2AQ3F-CGG1