### PR TITLE
Remove old code

### DIFF
--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
     DEVICE_CLASS_LIGHT,
     DEVICE_CLASS_MOISTURE,
     DEVICE_CLASS_MOTION,
@@ -11,11 +12,6 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_SMOKE,
 )
-
-try:
-    from homeassistant.components.binary_sensor import BinarySensorEntity
-except ImportError:
-    from homeassistant.components.binary_sensor import BinarySensorDevice as BinarySensorEntity
 
 from homeassistant.const import (
     CONF_DEVICES,

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -15,6 +15,6 @@
     "@Magalex2x14",
     "@Thrilleratplay"
   ],
-  "version": "4.6.1-beta",
+  "version": "4.6.2-beta",
   "iot_class": "local_polling"
 }

--- a/custom_components/ble_monitor/sensor.py
+++ b/custom_components/ble_monitor/sensor.py
@@ -5,35 +5,28 @@ import logging
 import statistics as sts
 
 from homeassistant.const import (
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_VOLTAGE,
-    CONDUCTIVITY,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_KILO_WATT,
-    PRESSURE_HPA,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
     ATTR_BATTERY_LEVEL,
+    CONDUCTIVITY,
     CONF_DEVICES,
     CONF_NAME,
     CONF_TEMPERATURE_UNIT,
     CONF_UNIQUE_ID,
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
+    ELECTRIC_POTENTIAL_VOLT,
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    POWER_KILO_WATT,
+    PRESSURE_HPA,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT
 )
-
-try:
-    from homeassistant.const import PERCENTAGE
-except ImportError:
-    from homeassistant.const import UNIT_PERCENTAGE as PERCENTAGE
-try:
-    from homeassistant.const import ELECTRIC_POTENTIAL_VOLT
-except ImportError:
-    from homeassistant.const import VOLT as ELECTRIC_POTENTIAL_VOLT
 
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity


### PR DESCRIPTION
This PR removes some old backwards compatibility code. Since 4.5.1 needs Home Assistant 2021.8 anywaysince 4.5.1, it is no longer needed to keep this backwards compatibility. 

Note. 2021.8 is needed for the new sensor_class, which we added in 4.5.1. I don’t see an easy way to make this backwards compatible, 