### PR TITLE
Device specific output from parser

### DIFF
--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -11,6 +11,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "5.2.1",
+  "version": "5.3.0",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
The `button/remote/switch/dimmer` advertisements and `light/motion/illuminance` advertisements of Xiaomi sensors are now only returning the output that correspond to the device that has sent the advertisements. 

In the previous versions, bleparser was giving all possible outputs for all device types that use the same data object (`0x000F` and `0x1001`). It now only returns the device specific results (e.g. a `dimmer` won't return a `bathroom remote command` anymore). 