### PR TITLE
Capture hciconfig error

### DIFF
--- a/custom_components/ble_monitor/bt_helpers.py
+++ b/custom_components/ble_monitor/bt_helpers.py
@@ -33,7 +33,7 @@ try:
     BT_MAC_INTERFACES = list(BT_INTERFACES.values())
     DEFAULT_BT_INTERFACE = list(BT_INTERFACES.items())[0][1]
     DEFAULT_HCI_INTERFACE = list(BT_INTERFACES.items())[0][0]
-except (IndexError, OSError):
+except (IndexError, OSError, subprocess.CalledProcessError):
     BT_INTERFACES = {0: "00:00:00:00:00:00"}
     DEFAULT_BT_INTERFACE = "00:00:00:00:00:00"
     DEFAULT_HCI_INTERFACE = 0


### PR DESCRIPTION
Hi !

Since `5.1.0-beta` (inclusive) version I had problems to run my HomeAssistant config test on GitHub CI. I saw the following error when I exec the command `/usr/local/bin/hass -c=/config/ --script check_config`:
```
INFO:homeassistant.util.package:Attempting install of aioblescan>=0.2.8
Can't open HCI socket.: Address family not supported by protocol
Fatal error while loading config: Command '['hciconfig']' returned non-zero exit status 1.
Failed config
  General Errors: 
    - Command '['hciconfig']' returned non-zero exit status 1.
```
And also the next error while I tried to running hass as usual:
```
2021-09-25 17:57:55 INFO (SyncWorker_0) [homeassistant.util.package] Attempting install of aioblescan>=0.2.8
Can't open HCI socket.: Address family not supported by protocol
2021-09-25 17:58:01 ERROR (MainThread) [homeassistant.setup] Setup failed for ble_monitor: unknown error
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 207, in _async_setup_component
    component = integration.get_component()
  File "/usr/src/homeassistant/homeassistant/loader.py", line 516, in get_component
    cache[self.domain] = importlib.import_module(self.pkg_path)
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/config/custom_components/ble_monitor/__init__.py", line 73, in <module>
    from .bt_helpers import (
  File "/config/custom_components/ble_monitor/bt_helpers.py", line 31, in <module>
    BT_INTERFACES = hci_get_mac([0, 1, 2, 3])
  File "/config/custom_components/ble_monitor/bt_helpers.py", line 12, in hci_get_mac
    output = subprocess.run(
  File "/usr/local/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['hciconfig']' returned non-zero exit status 1.
```

After a bit of research, I found the [cause of the problem](https://github.com/custom-components/ble_monitor/compare/5.0.0...5.1.0-beta#diff-7fcfb11cf94cfae478452e97103a7c01528eb607ac4ef7d1ebebd0d0803125c3R13). Since that change, if `hciconfig` return an exit code different from `0` an error arised.

With this PR we capture that error.