### PR TITLE
Force update def per binary sensor

### DIFF
--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -228,7 +228,7 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
         self._attr_name = f"{description.name} {self._device_name}"
         self._attr_unique_id = f"{description.unique_id}{self._device_name}"
         self._attr_should_poll = False
-        self._attr_force_update = True
+        self._attr_force_update = description.force_update
         self._attr_extra_state_attributes = self._extra_state_attributes
         self._attr_device_info = {
             "identifiers": {(DOMAIN, self._extra_state_attributes["mac address"])},

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -132,6 +132,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble remote binary single press",
         unique_id="rb_single_press_",
         device_class=None,
+        force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="remote long press",
@@ -139,6 +140,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble remote binary long press",
         unique_id="rb_long_press_",
         device_class=None,
+        force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="switch",
@@ -146,6 +148,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble switch",
         unique_id="sw_",
         device_class=DEVICE_CLASS_POWER,
+        force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="opening",
@@ -153,6 +156,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble opening",
         unique_id="op_",
         device_class=DEVICE_CLASS_OPENING,
+        force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="light",
@@ -160,6 +164,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble light",
         unique_id="lt_",
         device_class=DEVICE_CLASS_LIGHT,
+        force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="moisture",
@@ -167,6 +172,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble moisture",
         unique_id="mo_",
         device_class=DEVICE_CLASS_MOISTURE,
+        force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="motion",
@@ -174,6 +180,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble motion",
         unique_id="mn_",
         device_class=DEVICE_CLASS_MOTION,
+        force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="weight removed",
@@ -182,6 +189,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         icon="mdi:weight",
         unique_id="wr_",
         device_class=None,
+        force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="smoke detector",
@@ -189,6 +197,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble smoke detector",
         unique_id="sd_",
         device_class=DEVICE_CLASS_SMOKE,
+        force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="fingerprint",
@@ -197,6 +206,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         icon="mdi:fingerprint",
         unique_id="fp_",
         device_class=None,
+        force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="lock",
@@ -204,6 +214,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble lock",
         unique_id="lock_",
         device_class=DEVICE_CLASS_LOCK,
+        force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
         key="toothbrush",
@@ -212,6 +223,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         unique_id="tb_",
         icon="mdi:toothbrush-electric",
         device_class=DEVICE_CLASS_POWER,
+        force_update=False,
     ),
 )
 

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -11,6 +11,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "5.3.2",
+  "version": "5.4.0",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
This release changes the update behavior of some binary sensors, see #510. In the old situation, all binary sensors updated their state on each BLE message, even if the state was the same as the old state. According to the [HA developers docs](https://developers.home-assistant.io/docs/core/entity#advanced-properties), this is not recommended, as it will will spam the state machine. However, this can't be changed for all binary sensors, as some do need to update on each BLE message (like remotes, switches, etc, while others don't. 

The following binary sensors will update on each state update, even if the state is the same (old behavior). 

- remote single press
- remote long press
- switch
- fingerprint
- lock

The following binary sensors will NOT update the state, if the state is the same as the previous state (changed behavior). 

- opening
- light
- moisture (wet/dry)
- motion
- weight removed
- smoke detector
- toothbrush

