### PR TITLE
Changed HACS badge within info.md

### DIFF
--- a/info.md
+++ b/info.md
@@ -1,5 +1,5 @@
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-green.svg)](https://github.com/custom-components/hacs)
 
 # Passive BLE Monitor integration
 


### PR DESCRIPTION
:tada: The component is within `hacs/default`

(not a massive change, though...)