### PR TITLE
Added parse_data service

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -65,9 +65,11 @@ CONF_DEVICE_TRACK = "track_device"
 CONF_DEVICE_TRACKER_SCAN_INTERVAL = "tracker_scan_interval"
 CONF_DEVICE_TRACKER_CONSIDER_HOME = "consider_home"
 CONF_DEVICE_DELETE_DEVICE = "delete device"
+CONF_PACKET = "packet"
 CONFIG_IS_FLOW = "is_flow"
 
 SERVICE_CLEANUP_ENTRIES = "cleanup_entries"
+SERVICE_PARSE_DATA = "parse_data"
 
 # Default values for configuration options
 DEFAULT_BT_AUTO_RESTART = False

--- a/custom_components/ble_monitor/services.yaml
+++ b/custom_components/ble_monitor/services.yaml
@@ -1,3 +1,12 @@
 cleanup_entries:
   # Description of the service
   description: Clean up of dangling devices of the BLE Montitor integration.
+parse_data:
+  # Description of the service
+  description: Send RAW HCI packet data to the BLE Montitor integration.
+  fields:
+    packet:
+      name: Packet
+      description: RAW HCI packet data hex
+      required: true
+      example: 043E2B02010000123456789ABC1F12161A1819416538C1A41B073915810B529F0F0B094154435F363534313139AA


### PR DESCRIPTION
Send RAW HCI packet data to the BLE Montitor integration, used by ESPHome [BLE Gateway](https://github.com/myhomeiot/esphome-components#ble-gateway)

We discussed this [here](https://community.home-assistant.io/t/passive-ble-monitor-integration/303583/190?u=myhomeiot)

This code tested and fully working but I will be glad if you take a look into `async_parse_data_service` function and change it as you think it's should be.

Thanks in advance!

PS: You can also add [user permission check](https://developers.home-assistant.io/blog/2019/03/11/user-permissions) for service calls to prevent regular users calling services, by changing 

```
    hass.services.async_register(
        DOMAIN,
        SERVICE_CLEANUP_ENTRIES,
        service_cleanup_entries,
        schema=SERVICE_CLEANUP_ENTRIES_SCHEMA,
    )
```
to
```
    platform = entity_platform.async_get_current_platform()
    platform.async_register_entity_service(
        SERVICE_CLEANUP_ENTRIES,
        SERVICE_CLEANUP_ENTRIES_SCHEMA,
        "async_cleanup_entries_service"
    )
```

As example in my integration I did it in this [commit](https://github.com/myhomeiot/DahuaVTO/commit/d23268848921adf7d065d68ece234af82b9ff3b0)