### PR TITLE
Use new (Binary)SensorDeviceClass enums in ble_monitor

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -593,7 +593,7 @@ MEASUREMENT_DICT = {
     'LYWSD03MMC'              : [["temperature", "humidity", "battery", "voltage", "rssi"], [], []],
     'XMWSDJ04MMC'             : [["temperature", "humidity", "battery", "rssi"], [], []],
     'XMMF01JQD'               : [["rssi"], ["button"], []],
-    'HHCCJCY01'               : [["temperature", "moisture", "conductivity", "illuminance", "rssi"], [], []],
+    'HHCCJCY01'               : [["temperature", "moisture", "conductivity", "illuminance", "battery", "rssi"], [], []],
     'GCLS002'                 : [["temperature", "moisture", "conductivity", "illuminance", "rssi"], [], []],
     'HHCCPOT002'              : [["moisture", "conductivity", "rssi"], [], []],
     'WX08ZM'                  : [["consumable", "battery", "rssi"], [], ["switch"]],

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -4,30 +4,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_LIGHT,
-    DEVICE_CLASS_LOCK,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_OPENING,
-    DEVICE_CLASS_SMOKE,
+    BinarySensorDeviceClass,
     BinarySensorEntityDescription,
 )
 from homeassistant.components.sensor import (
-    STATE_CLASS_MEASUREMENT,
+    SensorDeviceClass,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.const import (
     CONDUCTIVITY,
     CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_SIGNAL_STRENGTH,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_VOLTAGE,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -39,10 +26,15 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
     VOLUME_LITERS,
+    Platform,
 )
 
 DOMAIN = "ble_monitor"
-PLATFORMS = ["binary_sensor", "device_tracker", "sensor"]
+PLATFORMS = [
+    Platform.DEVICE_TRACKER,
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+]
 
 # Configuration options
 CONF_BT_AUTO_RESTART = "bt_auto_restart"
@@ -154,7 +146,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="BaseBinarySensor",
         name="ble switch",
         unique_id="sw_",
-        device_class=DEVICE_CLASS_POWER,
+        device_class=BinarySensorDeviceClass.POWER,
         force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -162,7 +154,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="BaseBinarySensor",
         name="ble opening",
         unique_id="op_",
-        device_class=DEVICE_CLASS_OPENING,
+        device_class=BinarySensorDeviceClass.OPENING,
         force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -170,7 +162,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="BaseBinarySensor",
         name="ble light",
         unique_id="lt_",
-        device_class=DEVICE_CLASS_LIGHT,
+        device_class=BinarySensorDeviceClass.LIGHT,
         force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -178,7 +170,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="BaseBinarySensor",
         name="ble moisture",
         unique_id="mo_",
-        device_class=DEVICE_CLASS_MOISTURE,
+        device_class=BinarySensorDeviceClass.MOISTURE,
         force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -186,7 +178,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="MotionBinarySensor",
         name="ble motion",
         unique_id="mn_",
-        device_class=DEVICE_CLASS_MOTION,
+        device_class=BinarySensorDeviceClass.MOTION,
         force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -203,7 +195,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="BaseBinarySensor",
         name="ble smoke detector",
         unique_id="sd_",
-        device_class=DEVICE_CLASS_SMOKE,
+        device_class=BinarySensorDeviceClass.SMOKE,
         force_update=False,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -220,7 +212,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         sensor_class="BaseBinarySensor",
         name="ble lock",
         unique_id="lock_",
-        device_class=DEVICE_CLASS_LOCK,
+        device_class=BinarySensorDeviceClass.LOCK,
         force_update=True,
     ),
     BLEMonitorBinarySensorEntityDescription(
@@ -229,7 +221,7 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
         name="ble toothbrush",
         unique_id="tb_",
         icon="mdi:toothbrush-electric",
-        device_class=DEVICE_CLASS_POWER,
+        device_class=BinarySensorDeviceClass.POWER,
         force_update=False,
     ),
 )
@@ -242,8 +234,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble temperature",
         unique_id="t_",
         native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="temperature outdoor",
@@ -251,8 +243,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble temperature outdoor",
         unique_id="t_outdoor_",
         native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="humidity",
@@ -260,8 +252,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble humidity",
         unique_id="h_",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=DEVICE_CLASS_HUMIDITY,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="humidity outdoor",
@@ -269,8 +261,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble temperature outdoor",
         unique_id="h_outdoor_",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=DEVICE_CLASS_HUMIDITY,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="moisture",
@@ -278,8 +270,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble moisture",
         unique_id="m_",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=DEVICE_CLASS_HUMIDITY,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="pressure",
@@ -287,8 +279,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble pressure",
         unique_id="p_",
         native_unit_of_measurement=PRESSURE_HPA,
-        device_class=DEVICE_CLASS_PRESSURE,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="conductivity",
@@ -298,16 +290,16 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:lightning-bolt-circle",
         native_unit_of_measurement=CONDUCTIVITY,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="illuminance",
         sensor_class="MeasuringSensor",
         name="ble illuminance",
         unique_id="l_",
-        device_class=DEVICE_CLASS_ILLUMINANCE,
+        device_class=SensorDeviceClass.ILLUMINANCE,
         native_unit_of_measurement=LIGHT_LUX,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="formaldehyde",
@@ -317,7 +309,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:chemical-weapon",
         native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="dewpoint",
@@ -326,8 +318,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         unique_id="d_",
         icon="mdi:water",
         native_unit_of_measurement=TEMP_CELSIUS,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="rssi",
@@ -335,8 +327,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble rssi",
         unique_id="rssi_",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
@@ -345,8 +337,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble battery",
         unique_id="batt_",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=DEVICE_CLASS_BATTERY,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
@@ -355,8 +347,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble voltage",
         unique_id="v_",
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        device_class=DEVICE_CLASS_VOLTAGE,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
@@ -367,7 +359,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:recycle-variant",
         native_unit_of_measurement=PERCENTAGE,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="acceleration",
@@ -377,7 +369,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:axis-arrow",
         native_unit_of_measurement="mG",
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="weight",
@@ -387,7 +379,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:scale-bathroom",
         native_unit_of_measurement=MASS_KILOGRAMS,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="non-stabilized weight",
@@ -397,7 +389,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:scale-bathroom",
         native_unit_of_measurement=MASS_KILOGRAMS,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="impedance",
@@ -407,7 +399,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:omega",
         native_unit_of_measurement="Ohm",
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="energy",
@@ -415,8 +407,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble energy",
         unique_id="e_",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
-        device_class=DEVICE_CLASS_ENERGY,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="power",
@@ -424,8 +416,8 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble power",
         unique_id="pow_",
         native_unit_of_measurement=POWER_KILO_WATT,
-        device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="magnetic field",
@@ -435,7 +427,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:magnet",
         native_unit_of_measurement="µT",
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="magnetic field direction",
@@ -445,7 +437,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:compass",
         native_unit_of_measurement=None,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="button",
@@ -575,7 +567,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
         key="volume dispensed port 2",
@@ -585,7 +577,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         icon="mdi:keg",
         native_unit_of_measurement=VOLUME_LITERS,
         device_class=None,
-        state_class=STATE_CLASS_MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -5,12 +5,12 @@
   "documentation": "https://github.com/custom-components/ble_monitor",
   "issue_tracker": "https://github.com/custom-components/ble_monitor/issues",
   "requirements": [
-    "pycryptodomex>=3.11.0",
-    "janus>=0.6.2",
-    "aioblescan>=0.2.9"
+    "pycryptodomex>=3.12.0",
+    "janus>=0.7.0",
+    "aioblescan>=0.2.10"
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "6.2.0",
+  "version": "6.3.0-besta",
   "iot_class": "local_polling"
 }

--- a/docs/_devices/HHCCJCY01.md
+++ b/docs/_devices/HHCCJCY01.md
@@ -13,10 +13,7 @@ broadcasted_properties:
   - rssi
 broadcasted_property_notes:
   - property: battery
-    note: No battery info with firmware v3.2.1.
-  - property: rssi
-    note: >
-      The RSSI sensor is disabled by default. You can enable the RSSI sensor by going to `configuration`, `integrations`, select `devices` on the BLE monitor integration tile and select your device. Click on the `+1 disabled entity` to show the disabled sensor and select the disabled entity. Finally, click on `Enable entity` to enable it. 
+    note: No battery info with firmware v3.2.1. Battery sensor is only supported when using [BLE gateway](https://github.com/myhomeiot/esphome-components) to forward the BLE advertisements with ESPHome to BLE monitor.
 broadcast_rate: ~1/min.
 active_scan:
 encryption_key:

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Passive BLE monitor integration",
   "domains": "ble_monitor",
   "iot_class": "local push",
-  "homeassistant": "2021.11.0"
+  "homeassistant": "2021.12.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 pytest-homeassistant-custom-component==0.4.10
 
 # BLE montitor requirements
-pycryptodomex==3.11.0
-janus==0.6.2
-aioblescan==0.2.9
+pycryptodomex==3.12.0
+janus==0.7.0
+aioblescan==0.2.10

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest-homeassistant-custom-component==0.4.10
+pytest-homeassistant-custom-component==0.5.4
 
 # BLE montitor requirements
 pycryptodomex==3.12.0


### PR DESCRIPTION
This PR 
- Uses the new `BinarySensorDeviceClass`, `SensorDeviceClass` and `SensorStateClass` enums from HA 2021.12. 
- Bumps `pycryptodomex` to 3.12.0
- Bumps `janus` to 0.7.0
- Bumps `aioblescan` to 0.2.10
- Bumps `pytest-homeassistant-custom-component` to 0.5.4