### PR TITLE
Add switch and opening sensor to ATC

### DIFF
--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -289,6 +289,14 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
         return self.enabled and self.ready_for_update
 
     @property
+    def entity_registry_enabled_default(self):
+        """Return if the entity should be enabled when first added to the entity registry."""
+        if self._device_type == "ATC":
+            return False
+        else:
+            return True
+
+    @property
     def is_on(self):
         """Return true if the binary sensor is on."""
         return bool(self._state) if self._state is not None else None

--- a/custom_components/ble_monitor/ble_parser/atc.py
+++ b/custom_components/ble_monitor/ble_parser/atc.py
@@ -22,7 +22,8 @@ def parse_atc(self, data, source_mac, rssi):
             "voltage": volt / 1000,
             "battery": batt,
             "switch": (trg >> 1) & 1,
-            "opening": (trg ^ 1) & 1,
+            "opening": (~trg ^ 1) & 1,
+            "status": "opened",
             "data": True
         }
         adv_priority = 39
@@ -59,7 +60,8 @@ def parse_atc(self, data, source_mac, rssi):
                 "voltage": volt,
                 "battery": batt,
                 "switch": (trg >> 1) & 1,
-                "opening": (trg ^ 1) & 1,
+                "opening": (~trg ^ 1) & 1,
+                "status": "opened",
                 "data": True
             }
             adv_priority = 39

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -654,7 +654,7 @@ MEASUREMENT_DICT = {
     'YLYK01YL-VENFAN'         : [["rssi"], ["ventilator fan remote"], []],
     'YLYB01YL-BHFRC'          : [["rssi"], ["bathroom heater remote"], []],
     'YLKG07YL/YLKG08YL'       : [["rssi"], ["dimmer"], []],
-    'ATC'                     : [["temperature", "humidity", "battery", "voltage", "rssi"], [], []],
+    'ATC'                     : [["temperature", "humidity", "battery", "voltage", "rssi"], [], ["switch", "opening"]],
     'Mi Scale V1'             : [["rssi"], ["weight", "non-stabilized weight"], ["weight removed"]],
     'Mi Scale V2'             : [["rssi"], ["weight", "non-stabilized weight", "impedance"], ["weight removed"]],
     'TZC4'                    : [["rssi"], ["weight", "non-stabilized weight", "impedance"], []],

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -11,6 +11,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "6.4.3-beta",
+  "version": "6.5.0",
   "iot_class": "local_polling"
 }

--- a/docs/_devices/LYWSD03MMC.md
+++ b/docs/_devices/LYWSD03MMC.md
@@ -9,13 +9,18 @@ broadcasted_properties:
   - humidity
   - battery
   - voltage
+  - switch*
+  - opening*
   - rssi
 broadcasted_property_notes:
   - property: voltage
     note: battery voltage is only available with custom firmware
-  - property: rssi
+  - property: switch
     note: >
-      The RSSI sensor is disabled by default. You can enable the RSSI sensor by going to `configuration`, `integrations`, select `devices` on the BLE monitor integration tile and select your device. Click on the `+1 disabled entity` to show the disabled sensor and select the disabled entity. Finally, click on `Enable entity` to enable it. 
+      The `switch` sensor is only available with custom firmware and is disabled by default. It represents the state of the Reed Switch. You can enable the `switch` sensor by going to `configuration`, `integrations`, select `devices` on the BLE monitor integration tile and select your device. Click on the `+1 disabled entity` to show the disabled sensor and select the disabled entity. Finally, click on `Enable entity` to enable it.
+  - property: opening
+    note: >
+      The `opening` sensor is only available with custom firmware and is disabled by default. You can enable the `opening` sensor by going to `configuration`, `integrations`, select `devices` on the BLE monitor integration tile and select your device. Click on the `+1 disabled entity` to show the disabled sensor and select the disabled entity. Finally, click on `Enable entity` to enable it.
 broadcast_rate: 1/10min. (battery level ~1/hr.)*
 active_scan:
 encryption_key: Yes (original firmware)


### PR DESCRIPTION
This PR adds the switch and opening binary sensors to ATC devices. 

Note that these binary sensors are disabled by default. You can enable the `opening` and `switch` sensor by going to `configuration`, `integrations`, select `devices` on the BLE monitor integration tile and select your device. Click on the `+2 disabled entities` to show the disabled sensors and select the disabled entity. Finally, click on `Enable entity` to enable it.

Fix for #580 