### PR TITLE
Add b-parasite to list of supported sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This custom component for [Home Assistant](https://www.home-assistant.io) passiv
 - ATC (custom firmware for Xiaomi/Qingping sensors)
 - BlueMaestro
 - Brifit
+- b-parasite
 - Govee
 - Inkbird iBBQ
 - iNode sensors


### PR DESCRIPTION
Technically, b-parasite is not the brand but the specific device name, but if someone wants to know whether this sensor is supported by this integration, they will be looking for "b-parasite", not for the "rbaron" brand used in the internals.