### PR TITLE
Added passing the gateway ID

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -58,6 +58,7 @@ CONF_DEVICE_TRACKER_SCAN_INTERVAL = "tracker_scan_interval"
 CONF_DEVICE_TRACKER_CONSIDER_HOME = "consider_home"
 CONF_DEVICE_DELETE_DEVICE = "delete device"
 CONF_PACKET = "packet"
+CONF_GATEWAY_ID = "gateway_id"
 CONFIG_IS_FLOW = "is_flow"
 
 SERVICE_CLEANUP_ENTRIES = "cleanup_entries"

--- a/custom_components/ble_monitor/device_tracker.py
+++ b/custom_components/ble_monitor/device_tracker.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_DEVICE_TRACKER_SCAN_INTERVAL,
     CONF_DEVICE_TRACKER_CONSIDER_HOME,
     CONF_PERIOD,
+    CONF_GATEWAY_ID,
     DEFAULT_DEVICE_TRACK,
     DEFAULT_DEVICE_TRACKER_SCAN_INTERVAL,
     DEFAULT_DEVICE_TRACKER_CONSIDER_HOME,
@@ -197,6 +198,9 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
             )
         if "rssi" in old_state.attributes:
             self._extra_state_attributes["rssi"] = old_state.attributes["rssi"]
+        if CONF_GATEWAY_ID in old_state.attributes:
+            self._extra_state_attributes[CONF_GATEWAY_ID] = old_state.attributes[CONF_GATEWAY_ID]
+
         self.ready_for_update = True
 
     @property
@@ -326,6 +330,9 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
         self._last_seen = now
         self._extra_state_attributes["rssi"] = data["rssi"]
         self._extra_state_attributes["last seen"] = self._last_seen
+        if CONF_GATEWAY_ID in data:
+            self._extra_state_attributes[CONF_GATEWAY_ID] = data[CONF_GATEWAY_ID]
+
         self.ready_for_update = True
 
     def recheck_state(self, event=None):

--- a/custom_components/ble_monitor/services.yaml
+++ b/custom_components/ble_monitor/services.yaml
@@ -12,3 +12,9 @@ parse_data:
       example: 043E2B02010000123456789ABC1F12161A1819416538C1A41B073915810B529F0F0B094154435F363534313139AA
       selector:
         text:
+    gateway_id:
+      name: Gateway ID (only for device_tracker)
+      required: false
+      example: esp32_gateway
+      selector:
+        text:

--- a/custom_components/ble_monitor/services.yaml
+++ b/custom_components/ble_monitor/services.yaml
@@ -13,7 +13,8 @@ parse_data:
       selector:
         text:
     gateway_id:
-      name: Gateway ID (only for device_tracker)
+      name: Gateway ID
+      description: Identifier of the gateway that transmits the packet (only for device_tracker).
       required: false
       example: esp32_gateway
       selector:

--- a/docs/parse_data.md
+++ b/docs/parse_data.md
@@ -36,4 +36,59 @@ automation:
       - service: ble_monitor.parse_data
         data:
           packet: "{{ trigger.event.data.packet }}"
+          gateway_id: "{{ trigger.event.data.gateway_id }}" # Optional. If your gateway sends.
+```
+
+### Example ESPHome BLE Gateway
+
+Configuration example:
+
+```yaml
+substitutions:
+  board: esp32doit-devkit-v1 # Replace with your board.
+  
+  gateway_id: ble_gateway # Replace with your device name.
+
+  wifi_ssid: "esphome" # Replace with your wifi ssid.
+  wifi_password: "esphome" # Replace with your wifi password.
+
+  ota_password: "esphome"
+  api_password: "esphome"
+
+esphome:
+  name: $gateway_id
+  platform: ESP32
+  board: $board
+
+logger:
+
+api:
+  password: $api_password
+
+ota:
+  password: $ota_password
+
+wifi:
+  ssid: $wifi_ssid
+  password: $wifi_password
+  fast_connect: on
+
+external_components:
+  - source: github://myhomeiot/esphome-components
+  # For ESPHome 2021.12
+  # - source: github://pr#2854
+  #   components: [esp32_ble_tracker]
+
+esp32_ble_tracker:
+
+ble_gateway:
+  devices:
+    - mac_address: "00:00:00:00:00:00" # mac addresses of devices from which you want to receive packets.
+  on_ble_advertise:
+    then:
+      homeassistant.event:
+        event: esphome.on_ble_advertise
+        data:
+          packet: !lambda return packet;
+          gateway_id: $gateway_id
 ```


### PR DESCRIPTION
Added passing the gateway ID to determine exactly which gateway caught the device, particularly useful for identifying people in the room. 

#### Example for myhomeiot/esphhome-components:
**esphome**
```yaml
.....

external_components:
  - source: github://myhomeiot/esphome-components
  - source: github://pr#2854
    components: [esp32_ble_tracker]

esp32_ble_tracker:

ble_gateway:
  devices:
    - mac_address: ...
  on_ble_advertise:
    then:
      homeassistant.event:
        event: esphome.on_ble_advertise
        data:
          packet: !lambda return packet;
          gateway_id: gateway_hall_1
```

**hass**
```yaml
- alias: ESPHome BLE Advertise
  mode: queued
  trigger:
    - platform: event
      event_type: esphome.on_ble_advertise
  action:
    - service: ble_monitor.parse_data
      data:
        packet: "{{ trigger.event.data.packet }}"
        gateway_id: "{{ trigger.event.data.gateway_id }}"
```