### PR TITLE
Fix for not being able to change BT adapter after restoring settings on a new machine

### DIFF
--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -372,7 +372,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     blemonitor = BLEmonitor(config)
     hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, blemonitor.shutdown_handler)
-    if not config[CONF_HCI_INTERFACE] == "disable":
+    if not "disable" in config[CONF_HCI_INTERFACE]:
         blemonitor.start()
 
     hass.data[DOMAIN] = {}

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -293,17 +293,31 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         else:
             bt_interface_list = config[CONF_BT_INTERFACE]
             for bt_mac in bt_interface_list:
-                hci = list(BT_INTERFACES.keys())[
-                    list(BT_INTERFACES.values()).index(bt_mac)
-                ]
-                hci_list.append(int(hci))
-                bt_mac_list.append(str(bt_mac))
+                try:
+                    hci = list(BT_INTERFACES.keys())[
+                        list(BT_INTERFACES.values()).index(bt_mac)
+                    ]
+                    hci_list.append(int(hci))
+                    bt_mac_list.append(str(bt_mac))
+                except:
+                    _LOGGER.error(
+                        "Bluetooth adapter with MAC address %s was not found. "
+                        "It is therefore changed back to the default adapter. "
+                        "Check the BLE monitor settings, if needed.",
+                        config[CONF_BT_INTERFACE]
+                    )
+                    default_hci = list(BT_INTERFACES.keys())[
+                        list(BT_INTERFACES.values()).index(DEFAULT_BT_INTERFACE)
+                    ]
+                    hci_list.append(int(default_hci))
+                    bt_mac_list.append(str(DEFAULT_BT_INTERFACE))
     else:
         # Configuration in YAML
         for key, value in CONFIG_YAML.items():
             config[key] = value
         _LOGGER.info(
-            "Available Bluetooth interfaces for BLE monitor: %s", list(BT_MULTI_SELECT.values())
+            "Available Bluetooth interfaces for BLE monitor: %s",
+            list(BT_MULTI_SELECT.values())
         )
 
         if config[CONF_HCI_INTERFACE]:

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -299,7 +299,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                     ]
                     hci_list.append(int(hci))
                     bt_mac_list.append(str(bt_mac))
-                except:
+                except ValueError:
                     _LOGGER.error(
                         "Bluetooth adapter with MAC address %s was not found. "
                         "It is therefore changed back to the default adapter. "
@@ -372,7 +372,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     blemonitor = BLEmonitor(config)
     hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, blemonitor.shutdown_handler)
-    if not config[CONF_BT_INTERFACE] == "disable":
+    if not config[CONF_HCI_INTERFACE] == "disable":
         blemonitor.start()
 
     hass.data[DOMAIN] = {}

--- a/custom_components/ble_monitor/ble_parser/altbeacon.py
+++ b/custom_components/ble_monitor/ble_parser/altbeacon.py
@@ -1,15 +1,12 @@
-# Parser for AltBeacon BLE advertisements
+"""Parser for AltBeacon BLE advertisements"""
 import logging
 from struct import unpack
 from uuid import UUID
 from typing import Final
 
-from homeassistant.const import (
-    CONF_MAC,
-    CONF_TYPE
-)
-
 from .const import (
+    CONF_MAC,
+    CONF_TYPE,
     CONF_PACKET,
     CONF_FIRMWARE,
     CONF_MANUFACTURER,
@@ -28,6 +25,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 DEVICE_TYPE: Final = "AltBeacon"
+
 
 def parse_altbeacon(self, data: str, comp_id: int, source_mac: str, rssi: float):
     if len(data) >= 27:
@@ -64,7 +62,7 @@ def parse_altbeacon(self, data: str, comp_id: int, source_mac: str, rssi: float)
             )
         return None, None
 
-     # check for UUID presence in sensor whitelist, if needed
+    # check for UUID presence in sensor whitelist, if needed
     if self.discovery is False and uuid and uuid not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. UUID: %s is not whitelisted!", to_uuid(uuid))
 
@@ -72,8 +70,10 @@ def parse_altbeacon(self, data: str, comp_id: int, source_mac: str, rssi: float)
 
     return sensor_data, tracker_data
 
+
 def to_uuid(uuid: str) -> str:
     return str(UUID(''.join('{:02X}'.format(x) for x in uuid)))
+
 
 def to_mac(addr: str) -> str:
     return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/custom_components/ble_monitor/ble_parser/bparasite.py
+++ b/custom_components/ble_monitor/ble_parser/bparasite.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 def parse_bparasite(self, data, source_mac, rssi):
     """Check for adstruc length"""
     msg_length = len(data)
-    if msg_length == 22: # TODO: Use version bits?
+    if msg_length == 22:  # TODO: Use version bits?
         bpara_mac = data[14:20]
         device_type = "b-parasite V1.1.0"
         firmware = "b-parasite V1.1.0 (with illuminance)"
@@ -53,7 +53,7 @@ def parse_bparasite(self, data, source_mac, rssi):
     except KeyError:
         # start with empty first packet
         prev_packet = None
-    
+
     if self.filter_duplicates is True:
         # only process messages with same priority that have a changed packet id
         if prev_packet == packet_id:
@@ -70,4 +70,3 @@ def parse_bparasite(self, data, source_mac, rssi):
     })
 
     return result
-

--- a/custom_components/ble_monitor/ble_parser/const.py
+++ b/custom_components/ble_monitor/ble_parser/const.py
@@ -1,11 +1,11 @@
 from typing import Final
-from homeassistant.const import CONF_SERVICE_DATA, ATTR_MANUFACTURER
 
+CONF_MAC: Final = "mac"
+CONF_TYPE: Final = "type"
 CONF_PACKET: Final = "packet"
 CONF_FIRMWARE: Final = "firmware"
-CONF_PACKET: Final = "packet"
-CONF_DATA: Final = CONF_SERVICE_DATA
-CONF_MANUFACTURER: Final = ATTR_MANUFACTURER
+CONF_DATA: Final = "data"
+CONF_MANUFACTURER: Final = "manufacturer"
 CONF_RSSI: Final = "rssi"
 
 CONF_UUID: Final = "uuid"
@@ -554,5 +554,5 @@ MANUFACTURER_DICT: Final = {
     0x0215: "Lukoton Experience Oy",
     0x0216: "MTI Ltd",
     0x0217: "Tech4home, Lda",
-    0x0216: "Hiotech AB",
+    0x0218: "Hiotech AB",
 }

--- a/custom_components/ble_monitor/ble_parser/ibeacon.py
+++ b/custom_components/ble_monitor/ble_parser/ibeacon.py
@@ -1,15 +1,12 @@
-# Parser for iBeacon BLE advertisements
+"""Parser for iBeacon BLE advertisements"""
 import logging
 from struct import unpack
 from uuid import UUID
 from typing import Final
 
-from homeassistant.const import (
+from .const import (
     CONF_MAC,
     CONF_TYPE,
-)
-
-from .const import (
     CONF_PACKET,
     CONF_FIRMWARE,
     CONF_DATA,
@@ -26,6 +23,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 DEVICE_TYPE: Final = "iBeacon"
+
 
 def parse_ibeacon(self, data: str, source_mac: str, rssi: float):
     if data[5] == 0x15 and len(data) >= 27:
@@ -69,8 +67,10 @@ def parse_ibeacon(self, data: str, source_mac: str, rssi: float):
 
     return sensor_data, tracker_data
 
+
 def to_uuid(uuid: str) -> str:
     return str(UUID(''.join('{:02X}'.format(x) for x in uuid)))
+
 
 def to_mac(addr: str) -> str:
     return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -11,6 +11,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.3.5-beta",
+  "version": "7.3.6-beta",
   "iot_class": "local_polling"
 }

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -11,6 +11,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.3.4-beta",
+  "version": "7.3.5-beta",
   "iot_class": "local_polling"
 }

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -11,6 +11,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.3.6-beta",
+  "version": "7.3.7-beta",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
- Fix for not being able to change BT adapter after restoring settings on a new machine
- Fix for errors when running with BT adapter disabled
- Remove dependency of homeassistant package from parser 