### PR TITLE
aioblescan BLEScanRequester initialisation control

### DIFF
--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -627,18 +627,20 @@ class HCIdump(Thread):
 
     def run(self):
         """Run HCIdump thread."""
-        interface_is_ok = {}
         while True:
             _LOGGER.debug("HCIdump thread: Run")
             mysocket = {}
             fac = {}
             conn = {}
             btctrl = {}
+            interface_is_ok = {}
+            initialized_evt = {}
             if self._event_loop is None:
                 self._event_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._event_loop)
             if "disable" not in self.config[CONF_BT_INTERFACE]:
                 for hci in self._interfaces:
+                    interface_is_ok[hci] = False
                     try:
                         mysocket[hci] = aiobs.create_bt_socket(hci)
                     except OSError as error:
@@ -650,27 +652,21 @@ class HCIdump(Thread):
                         conn[hci], btctrl[hci] = self._event_loop.run_until_complete(
                             fac[hci]
                         )
-                        interface_is_ok[hci] = False
                         # Wait up to five seconds for aioblescan BLEScanRequester to initialize
-                        initialized_evt = getattr(btctrl[hci], "_initialized")
+                        initialized_evt[hci] = getattr(btctrl[hci], "_initialized")
+                        _LOGGER.debug(
+                            "HCIdump thread: aioblescan BLEScanRequester._initialized is %s for hci%i",
+                            initialized_evt[hci].is_set(),
+                            hci,
+                        )
                         try:
-                            self._event_loop.run_until_complete(asyncio.wait_for(initialized_evt.wait(), 5))
+                            self._event_loop.run_until_complete(asyncio.wait_for(initialized_evt[hci].wait(), 5))
                         except asyncio.TimeoutError:
                             _LOGGER.error(
                                 "HCIdump thread: Something wrong - interface hci%i not ready,"
                                 " and will be skipped for current scan period.",
                                 hci,
                             )
-                            if self.config[CONF_BT_AUTO_RESTART] is True:
-                                ts_now = dt_util.now()
-                                if (ts_now - self.last_bt_reset).seconds > 60:
-                                    _LOGGER.error(
-                                        "HCIdump thread: Trying to reset Bluetooth adapter %s,"
-                                        " will try to use it next scan period.",
-                                        BT_INTERFACES[hci],
-                                    )
-                                    reset_bluetooth(hci)
-                                    self.last_bt_reset = ts_now
                         else:
                             btctrl[hci].process = self.process_hci_events
                             _LOGGER.debug("HCIdump thread: connected to hci%i", hci)
@@ -678,18 +674,34 @@ class HCIdump(Thread):
                                 self._event_loop.run_until_complete(
                                     btctrl[hci].send_scan_request(self._active)
                                 )
-                                interface_is_ok[hci] = True
                             except RuntimeError as error:
                                 _LOGGER.error(
                                     "HCIdump thread: Runtime error while sending scan request on hci%i: %s.",
                                     hci,
                                     error,
                                 )
+                            else:
+                                interface_is_ok[hci] = True
+                        _LOGGER.debug(
+                            "HCIdump thread: aioblescan BLEScanRequester._initialized is %s for hci%i",
+                            initialized_evt[hci].is_set(),
+                            hci,
+                        )
+                    if (self.config[CONF_BT_AUTO_RESTART] is True) and (interface_is_ok[hci] is False):
+                        ts_now = dt_util.now()
+                        if (ts_now - self.last_bt_reset).seconds > 60:
+                            _LOGGER.error(
+                                "HCIdump thread: Trying to reset Bluetooth adapter %s,"
+                                " will try to use it next scan period.",
+                                BT_INTERFACES[hci],
+                            )
+                            reset_bluetooth(hci)
+                            self.last_bt_reset = ts_now
             _LOGGER.debug("HCIdump thread: start main event_loop")
             try:
                 self._event_loop.run_forever()
             finally:
-                _LOGGER.debug("HCIdump thread: main event_loop stopped, finishing")
+                _LOGGER.debug("HCIdump thread: main event_loop stopped, finishing.")
                 if "disable" not in self.config[CONF_BT_INTERFACE]:
                     for hci in self._interfaces:
                         if interface_is_ok[hci] is True:

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -655,7 +655,8 @@ class HCIdump(Thread):
                         # Wait up to five seconds for aioblescan BLEScanRequester to initialize
                         initialized_evt[hci] = getattr(btctrl[hci], "_initialized")
                         _LOGGER.debug(
-                            "HCIdump thread: aioblescan BLEScanRequester._initialized is %s for hci%i",
+                            "HCIdump thread: aioblescan BLEScanRequester._initialized is %s for hci%i, "
+                            " waiting for connection...",
                             initialized_evt[hci].is_set(),
                             hci,
                         )
@@ -682,11 +683,12 @@ class HCIdump(Thread):
                                 )
                             else:
                                 interface_is_ok[hci] = True
-                        _LOGGER.debug(
-                            "HCIdump thread: aioblescan BLEScanRequester._initialized is %s for hci%i",
-                            initialized_evt[hci].is_set(),
-                            hci,
-                        )
+                                _LOGGER.debug(
+                                    "HCIdump thread: aioblescan BLEScanRequester._initialized is %s for hci%i, "
+                                    " connection established, send_scan_request succeeded.",
+                                    initialized_evt[hci].is_set(),
+                                    hci,
+                                )
                     if (self.config[CONF_BT_AUTO_RESTART] is True) and (interface_is_ok[hci] is False):
                         ts_now = dt_util.now()
                         if (ts_now - self.last_bt_reset).seconds > 60:

--- a/custom_components/ble_monitor/bt_helpers.py
+++ b/custom_components/ble_monitor/bt_helpers.py
@@ -81,11 +81,15 @@ def rfkill_block_bluetooth():
 def rfkill_unblock_bluetooth():
     """Execute the rfkill unblock bluetooth command."""
     _LOGGER.debug("rfkill unblock bluetooth.....")
-    command = subprocess.run(["rfkill", "unblock", "bluetooth"], stderr=subprocess.PIPE, check=True)
-    stderr = command.stderr
-    if command.returncode != 0:
-        _LOGGER.error("executing rfkill unblock bluetooth failed: %s", stderr)
-        return
+    try:
+        command = subprocess.run(["rfkill", "unblock", "bluetooth"], stderr=subprocess.PIPE, check=True)
+        stderr = command.stderr
+    except subprocess.CalledProcessError as error:
+        _LOGGER.error("executing rfkill unblock bluetooth failed: %s", error)
+    else:
+        if command.returncode != 0:
+            _LOGGER.error("executing rfkill unblock bluetooth failed: %s", stderr)
+    return
 
 
 # Bluetoothctl commands
@@ -148,7 +152,7 @@ def reset_bluetooth(hci):
     _LOGGER.debug("resetting Bluetooth")
 
     # Select the Bluetooth adapter and retreive the state of the adapter
-    mac = hci_get_mac([hci])[0]
+    mac = hci_get_mac([hci])[hci]
     if not mac:
         _LOGGER.error(
             "HCI%i seems not to exist (anymore), check BT interface mac address in your settings ",


### PR DESCRIPTION
Looks like it works for me. Also there is some fixes for bluetooth_reset procedure (rfkill execution failed and killed the HCIdump thread). I also noticed that the bluetoothctl utility hangs if the bluetooth daemon is not running, and hangs up the whole process for us.

Please test it yourself (need a test on a system with one interface).
You can simulate problems with the command `btmgmt --index 0 power off`