### PR TITLE
Support for the Sensirion SCD4x CO₂ Gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This custom component for [Home Assistant](https://www.home-assistant.io) passiv
 - Oral-B
 - Qingping
 - Ruuvitag
+- Sensirion
 - SensorPush
 - Teltonika
 - Thermoplus

--- a/custom_components/ble_monitor/ble_parser/__init__.py
+++ b/custom_components/ble_monitor/ble_parser/__init__.py
@@ -22,6 +22,7 @@ from .xiaogui import parse_xiaogui
 from .bparasite import parse_bparasite
 from .ibeacon import parse_ibeacon
 from .altbeacon import parse_altbeacon
+from .sensirion import parse_sensirion
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -210,6 +211,9 @@ class BleParser:
                         break
                     elif man_spec_data[0] in [0x06, 0x08] and service_class_uuid128 == b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef':  # Sensorpush
                         sensor_data = parse_sensorpush(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0x06D5:  # Sensirion
+                        sensor_data = parse_sensirion(self, man_spec_data, complete_local_name, mac, rssi)
                         break
                     else:
                         unknown_sensor = True

--- a/custom_components/ble_monitor/ble_parser/const.py
+++ b/custom_components/ble_monitor/ble_parser/const.py
@@ -555,4 +555,5 @@ MANUFACTURER_DICT: Final = {
     0x0216: "MTI Ltd",
     0x0217: "Tech4home, Lda",
     0x0218: "Hiotech AB",
+    0x06D5: "Sensirion AG",
 }

--- a/custom_components/ble_monitor/ble_parser/sensirion.py
+++ b/custom_components/ble_monitor/ble_parser/sensirion.py
@@ -1,0 +1,111 @@
+# Parser for Sensirion BLE advertisements
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_sensirion(self, data, complete_local_name, source_mac, rssi):
+    """Sensirion parser"""
+    result = {"firmware": "Sensirion"}
+    sensirion_mac = source_mac
+    device_type = complete_local_name
+
+    if device_type != "MyCO2":
+        if self.report_unknown == "Sensirion":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Sensirion DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+    
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and source_mac.lower() not in self.sensor_whitelist:
+        _LOGGER.debug(
+            "Discovery is disabled. MAC: %s is not whitelisted!", to_mac(source_mac))
+        return None
+        
+    # not all of the following values are used yet, but this explains the full protocol
+    advertisementLength = data[0]  # redundant
+    advertisementType0 = data[1]   # redundant (see below)
+    companyId = data[2:3]  # redundant
+    byte_data = data[4:]
+    advertisementType = int(byte_data[0])
+    advSampleType = int(byte_data[1])
+    deviceName = f'{byte_data[2]:x}:{byte_data[3]:x}'  # shown in Sensirion MyAmbience app
+
+    if(advertisementType == 0):
+        samples = _parse_dataType(advSampleType, byte_data[4:])
+        
+        if not samples:
+            return None
+        else:
+            result.update(samples)
+            result.update({
+                "rssi": rssi,
+                "mac": to_mac(source_mac),
+                "type": device_type,
+                "packet": "no packet id",
+                "data": True
+            })
+
+        return result
+    else:
+        _LOGGER.debug("Advertisement Type %s not supported ", advertisementType)
+        return None
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+
+
+'''
+The following functions are based on Sensirion_GadgetBle_Lib.cpp from  https://github.com/Sensirion/arduino-ble-gadget/
+support from other devices should be easily added by looking at GadgetBle::setDataType and updating _parse_dataType accordingly
+'''
+
+
+def _parse_dataType(advSampleType, byte_data):
+    if(advSampleType == 8):
+        return {'temperature': _decodeTemperatureV1(byte_data[0:2]),
+                'humidity': _decodeHumidityV1(byte_data[2:4]),
+                'co2': _decodeSimple(byte_data[4:6])}
+    else:
+        _LOGGER.debug("Advertisement SampleType %s not supported", advSampleType)
+       
+
+def _decodeSimple(byte_data):
+    # GadgetBle::_convertSimple - return static_cast<uint16_t>(value + 0.5f);
+    return int.from_bytes(byte_data, byteorder='little')
+
+
+def _decodeTemperatureV1(byte_data):
+    # GadgetBle::_convertTemperatureV1 - return static_cast<uint16_t>((((value + 45) / 175) * 65535) + 0.5f);
+    return (int.from_bytes(byte_data, byteorder='little') / 65535) * 175 - 45
+
+
+def _decodeHumidityV1(byte_data):
+    # GadgetBle::_convertHumidityV1 - return static_cast<uint16_t>(((value / 100) * 65535) + 0.5f);
+    return (int.from_bytes(byte_data, byteorder='little') / 65535) * 100
+
+
+def _decodeHumidityV2(byte_data):
+    # GadgetBle::_convertHumidityV2 - return static_cast<uint16_t>((((value + 6.0) * 65535) / 125.0) + 0.5f);
+    return
+
+
+def _decodePM2p5V1(byte_data):
+    # GadgetBle::_convertPM2p5V1 - return static_cast<uint16_t>(((value / 1000) * 65535) + 0.5f);
+    return
+
+
+def _decodePM2p5V2(byte_data):
+    # GadgetBle::_convertPM2p5V2 - return static_cast<uint16_t>((value * 10) + 0.5f);
+    return
+
+
+def _decodeHCHOV1(byte_data):
+    # GadgetBle::_convertHCHOV1 - return static_cast<uint16_t>((value * 5) + 0.5f);
+    return

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     TEMP_CELSIUS,
     VOLUME_LITERS,
+    CONCENTRATION_PARTS_PER_MILLION,
     Platform,
 )
 
@@ -726,6 +727,16 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    BLEMonitorSensorEntityDescription(
+        key="co2",
+        sensor_class="MeasuringSensor",
+        name="co2 sensor",
+        unique_id="co2_",
+        icon="mdi:molecule-co2",
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        device_class=SensorDeviceClass.CO2,
+     
+    ),
 )
 
 
@@ -824,6 +835,7 @@ MEASUREMENT_DICT = {
     'BEC07-5'                 : [["temperature", "humidity", "rssi"], [], []],
     'iBeacon'                 : [["rssi", "measured power", "cypress temperature", "cypress humidity"], ["uuid", "mac", "major", "minor"], []], # mac can be dynamic
     'AltBeacon'               : [["rssi", "measured power"], ["uuid", "mac", "major", "minor"], []], # mac can be dynamic
+    'MyCO2'                   : [["temperature", "humidity", "co2", "rssi"], [], []],
 }
 
 
@@ -904,6 +916,7 @@ MANUFACTURER_DICT = {
     'Blue Puck RHT'           : 'Teltonika',
     'HTP.xw'                  : 'SensorPush',
     'HT.w'                    : 'SensorPush',
+    'MyCO2'                   : 'Sensirion',
     'Moat S2'                 : 'Moat',
     'Tempo Disc THD'          : 'BlueMaestro',
     'Tempo Disc THPD'         : 'BlueMaestro',
@@ -943,6 +956,7 @@ REPORT_UNKNOWN_LIST = [
     "Qingping",
     "rbaron",
     "Ruuvitag",
+    "Sensirion",
     "SensorPush",
     "Teltonika",
     "Thermoplus",

--- a/custom_components/ble_monitor/test/test_sensirion_parser.py
+++ b/custom_components/ble_monitor/test/test_sensirion_parser.py
@@ -1,0 +1,24 @@
+"""The tests for the Sensirion ble_parser."""
+from ble_monitor.ble_parser import BleParser
+
+
+class TestSensirion:
+    """Tests for the Sensirion parser"""
+    def test_Sensorion_MyCO2(self):
+        """Test Sensirion MyCO2 parser."""
+        data_string = "043e320d0113000135673cdceaf80100ff7fb0000000000000000000180201060dffd506000867355367925c0b0406094d79434f32"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Sensirion"
+        assert sensor_msg["type"] == "MyCO2"
+        assert sensor_msg["mac"] == "F8:EA:DC:3C:67:35"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"] == True
+        assert sensor_msg["temperature"] == 25.63
+        assert sensor_msg["humidity"] == 36.16
+        assert sensor_msg["co2"] == 1035
+        assert sensor_msg["rssi"] == -80
+


### PR DESCRIPTION
This adds initial support for the [Sensirion SCD4x CO₂ Gadget](https://sensirion.com/products/catalog/SCD4x-CO2-Gadget/)  (Reference design for SCD4x CO₂ sensors).

![image](https://user-images.githubusercontent.com/748698/152180488-01bdb671-31b5-47b5-9f5c-d470b78acf27.png)



The protocol is public at [Sensirion/arduino-ble-gadget](https://github.com/Sensirion/arduino-ble-gadget/) and used to feed data into the Sensirion MyAmbience CO2 App (Android + iOS) 

The same protocol is used by a ton of other Sensirion BLE devices, though I haven't added support for them as I don't have them myself. It also doesn't implement any of the other bluetooth features (LED control, download of past data etc.)