### PR TITLE
Add HA BLE parser

### DIFF
--- a/custom_components/ble_monitor/ble_parser/__init__.py
+++ b/custom_components/ble_monitor/ble_parser/__init__.py
@@ -4,7 +4,9 @@ import logging
 from .atc import parse_atc
 from .bluemaestro import parse_bluemaestro
 from .brifit import parse_brifit
+from .const import GATT_CHARACTERISTICS
 from .govee import parse_govee
+from .ha_ble import parse_ha_ble
 from .inkbird import parse_inkbird
 from .inode import parse_inode
 from .jinou import parse_jinou
@@ -79,6 +81,7 @@ class BleParser:
         sensor_data = None
         tracker_data = None
         complete_local_name = ""
+        shortened_local_name = ""
         service_class_uuid16 = None
         service_class_uuid128 = None
         service_data_list = []
@@ -100,6 +103,9 @@ class BleParser:
                 elif adstuct_type == 0x06:
                     # AD type '128-bit Service Class UUIDs'
                     service_class_uuid128 = adstruct[2:]
+                elif adstuct_type == 0x08:
+                    # AD type 'shortened local name'
+                    shortened_local_name = adstruct[2:].decode("utf-8")
                 elif adstuct_type == 0x09:
                     # AD type 'complete local name'
                     complete_local_name = adstruct[2:].decode("utf-8")
@@ -135,6 +141,9 @@ class BleParser:
                         break
                     elif uuid16 == 0xFEAA:  # UUID16 = Ruuvitag V2/V4
                         sensor_data = parse_ruuvitag(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 in GATT_CHARACTERISTICS and shortened_local_name == "HA_BLE":
+                        sensor_data = parse_ha_ble(self, service_data_list, mac, rssi)
                         break
                     elif uuid16 == 0x2A6E or uuid16 == 0x2A6F:  # UUID16 = Teltonika
                         # Teltonika can contain multiple service data payloads in one advertisement

--- a/custom_components/ble_monitor/ble_parser/const.py
+++ b/custom_components/ble_monitor/ble_parser/const.py
@@ -18,6 +18,22 @@ CONF_CYPRESS_HUMIDITY: Final = "cypress humidity"
 
 DEFAULT_MANUFACTURER: Final = "Other"
 
+GATT_CHARACTERISTICS: Final = {
+    0x2A4D: "packet id",
+    0x2A19: "battery",
+    0x2A6D: "pressure",
+    0x2A6E: "temperature",
+    0x2A6F: "humidity",
+    0x2A7B: "dewpoint",
+    0x2A98: "weight",
+    0X2AF2: "energy",
+    0X2AFB: "illuminance",
+    0x2B05: "power",
+    0x2B18: "voltage",
+    0x2BD6: "pm2.5",
+    0x2BD7: "pm10",
+}
+
 MANUFACTURER_DICT: Final = {
     0x0000: "Ericsson Technology Licensing",
     0x0001: "Nokia Mobile Phones",

--- a/custom_components/ble_monitor/ble_parser/ha_ble.py
+++ b/custom_components/ble_monitor/ble_parser/ha_ble.py
@@ -45,7 +45,7 @@ def parse_ha_ble(self, service_data_list, source_mac, rssi):
             meas_type = (service_data[3] << 8) | service_data[2]
             xobj = service_data[4:]
             if meas_type == 0x2A4D and len(xobj) == 1:
-                (packet_id,) = struct.Struct("<b").unpack(xobj)
+                (packet_id,) = struct.Struct("<B").unpack(xobj)
                 result.update({"packet": packet_id})
             elif meas_type == 0x2A19 and len(xobj) == 1:
                 (batt,) = struct.Struct("<B").unpack(xobj)

--- a/custom_components/ble_monitor/ble_parser/ha_ble.py
+++ b/custom_components/ble_monitor/ble_parser/ha_ble.py
@@ -1,0 +1,126 @@
+"""Parser for HA BLE (DIY sensors) advertisements"""
+import logging
+import struct
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def to_int(value):
+    """Convert to integer"""
+    return value & 0xFF
+
+
+def unsigned_to_signed(unsigned, size):
+    """Convert unsigned to signed"""
+    if (unsigned & (1 << size - 1)) != 0:
+        unsigned = -1 * ((1 << size - 1) - (unsigned & ((1 << size - 1) - 1)))
+    return unsigned
+
+
+def to_sfloat(value):
+    """Convert sfloat to integer"""
+    if len(value) != 2:
+        _LOGGER.debug("conversion to sfloat failed")
+        return 0
+    else:
+        byte_0 = value[0]
+        byte_1 = value[1]
+
+        mantissa = unsigned_to_signed(to_int(byte_0) + ((to_int(byte_1) & 0x0F) << 8), 12)
+        exponent = unsigned_to_signed(to_int(byte_1) >> 4, 4)
+
+        return mantissa * pow(10, exponent)
+
+
+def parse_ha_ble(self, service_data_list, source_mac, rssi):
+    """Home Assistant BLE parser"""
+    firmware = "HA BLE"
+    device_type = "HA BLE DIY"
+    ha_ble_mac = source_mac
+    result = {}
+
+    for service_data in service_data_list:
+        if len(service_data) == service_data[0] + 1:
+            meas_type = (service_data[3] << 8) | service_data[2]
+            xobj = service_data[4:]
+            if meas_type == 0x2A4D and len(xobj) == 1:
+                result.update({"packet": struct.Struct("<b").unpack(xobj)})
+            elif meas_type == 0x2A19 and len(xobj) == 1:
+                (batt,) = struct.Struct("<B").unpack(xobj)
+                result.update({"battery": batt})
+            elif meas_type == 0x2A6D and len(xobj) == 4:
+                (press,) = struct.Struct("<I").unpack(xobj)
+                result.update({"pressure": press * 0.001})
+            elif meas_type == 0x2A6E and len(xobj) == 2:
+                (temp,) = struct.Struct("<h").unpack(xobj)
+                result.update({"temperature": temp * 0.01})
+            elif meas_type == 0x2A6F and len(xobj) == 2:
+                (humi,) = struct.Struct("<H").unpack(xobj)
+                result.update({"humidity": humi * 0.01})
+            elif meas_type == 0x2A7B and len(xobj) == 1:
+                (dewp,) = struct.Struct("<b").unpack(xobj)
+                result.update({"dewpoint": dewp})
+            elif meas_type == 0x2A98 and len(xobj) == 3:
+                (flag, weight) = struct.Struct("<bH").unpack(xobj)
+                if flag == 0:
+                    weight_unit = "kg"
+                    factor = 0.005
+                else:
+                    weight_unit = "lbs"
+                    factor = 0.01
+                result.update({"weight": weight * factor, "weight unit": weight_unit})
+            elif meas_type == 0X2AF2 and len(xobj) == 4:
+                (enrg,) = struct.Struct("<I").unpack(xobj)
+                result.update({"energy": enrg * 0.001})
+            elif meas_type == 0X2AFB and len(xobj) == 3:
+                illu = int.from_bytes(xobj, "little")
+                result.update({"illuminance": illu * 0.01})
+            elif meas_type == 0x2B05 and len(xobj) == 3:
+                power = int.from_bytes(xobj, "little")
+                result.update({"power": power * 0.1})
+            elif meas_type == 0x2B18 and len(xobj) == 2:
+                (volt,) = struct.Struct("<H").unpack(xobj)
+                result.update({"voltage": volt / 64})
+            elif meas_type == 0x2BD6 and len(xobj) == 2:
+                pm25 = to_sfloat(xobj)
+                result.update({"pm2.5": pm25})
+            elif meas_type == 0x2BD7 and len(xobj) == 2:
+                pm10 = to_sfloat(xobj)
+                result.update({"pm10": pm10})
+            else:
+                _LOGGER.debug(
+                    "Unknown data received from Home Assistant BLE DIY sensor device: %s",
+                    service_data.hex()
+                )
+
+    if not result:
+        if self.report_unknown == "HA BLE":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Home Assistant BLE DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                service_data_list
+            )
+        return None
+
+    if "packet" not in result:
+        result.update({"packet": "no packet id"})
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and ha_ble_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(ha_ble_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join(f'{i:02X}' for i in ha_ble_mac),
+        "type": device_type,
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/custom_components/ble_monitor/ble_parser/ha_ble.py
+++ b/custom_components/ble_monitor/ble_parser/ha_ble.py
@@ -62,12 +62,15 @@ def parse_ha_ble(self, service_data_list, source_mac, rssi):
                 result.update({"dewpoint": dewp})
             elif meas_type == 0x2A98 and len(xobj) == 3:
                 (flag, weight) = struct.Struct("<bH").unpack(xobj)
-                if flag == 0:
+                if flag << 0 == 0:
                     weight_unit = "kg"
                     factor = 0.005
-                else:
+                elif flag << 0 == 1:
                     weight_unit = "lbs"
                     factor = 0.01
+                else:
+                    weight_unit = "kg"
+                    factor = 0.005
                 result.update({"weight": weight * factor, "weight unit": weight_unit})
             elif meas_type == 0X2AF2 and len(xobj) == 4:
                 (enrg,) = struct.Struct("<I").unpack(xobj)

--- a/custom_components/ble_monitor/ble_parser/qingping.py
+++ b/custom_components/ble_monitor/ble_parser/qingping.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 def parse_qingping(self, data, source_mac, rssi):
     """Qingping parser"""
     msg_length = len(data)
-    if msg_length > 12 and data[4] in [0x08, 0x48]:
+    if msg_length > 12 and data[4] in [0x08, 0x48, 0x88]:
         firmware = "Qingping"
         device_id = data[5]
         if device_id == 0x01:

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -971,6 +971,7 @@ REPORT_UNKNOWN_LIST = [
     "BlueMaestro",
     "Brifit",
     "Govee",
+    "HA BLE",
     "Inkbird",
     "iNode",
     "iBeacon",

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -857,6 +857,7 @@ MEASUREMENT_DICT = {
     'iBeacon'                 : [["rssi", "measured power", "cypress temperature", "cypress humidity"], ["uuid", "mac", "major", "minor"], []],  # mac can be dynamic
     'AltBeacon'               : [["rssi", "measured power"], ["uuid", "mac", "major", "minor"], []],  # mac can be dynamic
     'MyCO2'                   : [["temperature", "humidity", "co2", "rssi"], [], []],
+    'HA BLE DIY'              : [["temperature", "rssi"], [], []],
 }
 
 
@@ -955,6 +956,7 @@ MANUFACTURER_DICT = {
     'BEC07-5'                 : 'Jinou',
     'iBeacon'                 : 'Apple',
     'AltBeacon'               : 'Radius Networks',
+    'HA BLE DIY'              : 'Home Assistant DIY',
 }
 
 # Renamed model dictionary

--- a/custom_components/ble_monitor/test/test_ha_ble.py
+++ b/custom_components/ble_monitor/test/test_ha_ble.py
@@ -1,0 +1,90 @@
+"""The tests for the HA BLE (DIY sensor) ble_parser."""
+from ble_monitor.ble_parser import BleParser
+
+
+class TestHaBle:
+    """Tests for the HA BLE (DIY sensor) parser"""
+    def test_ha_ble_battery(self):
+        """Test HA BLE parser for battery measurement"""
+        data_string = "043e1c02010000a5808fe6485410020106070848415f424c450416192a59cc"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["battery"] == 89
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_temperature(self):
+        """Test HA BLE parser for temperature measurement"""
+        data_string = "043E1D02010000A5808FE6485411020106070848415F424C4505166E2A3409CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 23.56
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_illuminance(self):
+        """Test HA BLE parser for illuminance measurement"""
+        data_string = "043E1E02010000A5808FE6485412020106070848415F424C450616FB2A34AA00CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["illuminance"] == 435.72
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_pm25(self):
+        """Test HA BLE parser for PM2.5 measurement"""
+        data_string = "043E1D02010000A5808FE6485411020106070848415F424C450516D62BAA00BC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["pm2.5"] == 170
+        assert sensor_msg["rssi"] == -68
+
+    def test_ha_ble_pm10(self):
+        """Test HA BLE parser for PM10 measurement"""
+        data_string = "043E1D02010000A5808FE6485411020106070848415F424C450516D72BAB01CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["pm10"] == 427
+        assert sensor_msg["rssi"] == -52

--- a/custom_components/ble_monitor/test/test_ha_ble.py
+++ b/custom_components/ble_monitor/test/test_ha_ble.py
@@ -21,6 +21,23 @@ class TestHaBle:
         assert sensor_msg["battery"] == 89
         assert sensor_msg["rssi"] == -52
 
+    def test_ha_ble_pressure(self):
+        """Test HA BLE parser for pressure measurement"""
+        data_string = "043E1F02010000A5808FE6485413020106070848415F424C4507166D2A78091000CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["pressure"] == 1051.0
+        assert sensor_msg["rssi"] == -52
+
     def test_ha_ble_temperature(self):
         """Test HA BLE parser for temperature measurement"""
         data_string = "043E1D02010000A5808FE6485411020106070848415F424C4505166E2A3409CC"
@@ -38,6 +55,110 @@ class TestHaBle:
         assert sensor_msg["temperature"] == 23.56
         assert sensor_msg["rssi"] == -52
 
+    def test_ha_ble_temperature_packet_nr(self):
+        """Test HA BLE parser for temperature measurement with packet number """
+        data_string = "043E2202010000A5808FE6485416020106070848415F424C4504164D2A0605166E2A3409CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == 6
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 23.56
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_humidity(self):
+        """Test HA BLE parser for humidity measurement"""
+        data_string = "043E1D02010000A5808FE6485411020106070848415F424C4505166F2A5419CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["humidity"] == 64.84
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_dewpoint(self):
+        """Test HA BLE parser for dewpoint measurement"""
+        data_string = "043e1c02010000a5808fe6485410020106070848415f424c4504167b2a18cc"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["dewpoint"] == 24
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_weight_kg(self):
+        """Test HA BLE parser for weight measurement in kg"""
+        data_string = "043E1E02010000A5808FE6485412020106070848415F424C450616982A00AA33CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["weight"] == 66.13
+        assert sensor_msg["weight unit"] == "kg"
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_weight_lbs(self):
+        """Test HA BLE parser for weight measurement in lbs"""
+        data_string = "043E1E02010000A5808FE6485412020106070848415F424C450616982A01AA33CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["weight"] == 132.26
+        assert sensor_msg["weight unit"] == "lbs"
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_energy(self):
+        """Test HA BLE parser for energy measurement"""
+        data_string = "043E1F02010000A5808FE6485413020106070848415F424C450716F22A81121000CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["energy"] == 1053.313
+        assert sensor_msg["rssi"] == -52
+
     def test_ha_ble_illuminance(self):
         """Test HA BLE parser for illuminance measurement"""
         data_string = "043E1E02010000A5808FE6485412020106070848415F424C450616FB2A34AA00CC"
@@ -53,6 +174,40 @@ class TestHaBle:
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
         assert sensor_msg["illuminance"] == 435.72
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_power(self):
+        """Test HA BLE parser for power measurement"""
+        data_string = "043E1E02010000A5808FE6485412020106070848415F424C450616052B510A00CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["power"] == 264.1
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_voltage(self):
+        """Test HA BLE parser for voltage measurement"""
+        data_string = "043E1D02010000A5808FE6485411020106070848415F424C450516182BB400CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["voltage"] == 2.8125
         assert sensor_msg["rssi"] == -52
 
     def test_ha_ble_pm25(self):
@@ -87,4 +242,22 @@ class TestHaBle:
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
         assert sensor_msg["pm10"] == 427
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_voltage_power(self):
+        """Test HA BLE parser for voltage + power measurement"""
+        data_string = "043E2402010000A5808FE6485418020106070848415F424C450516182BB4000616052B510A00CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["voltage"] == 2.8125
+        assert sensor_msg["power"] == 264.1
         assert sensor_msg["rssi"] == -52

--- a/custom_components/ble_monitor/test/test_jinou.py
+++ b/custom_components/ble_monitor/test/test_jinou.py
@@ -21,5 +21,3 @@ class TestJinou:
         assert sensor_msg["temperature"] == 18.7
         assert sensor_msg["humidity"] == 54.2
         assert sensor_msg["rssi"] == -37
-
-    

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -2,6 +2,6 @@
 layout: default
 title: Technical and development documentation
 permalink: developer_docs
-nav_order: 6
+nav_order: 8
 has_children: true
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 layout: default
 title: FAQ
 permalink: faq
-nav_order: 4
+nav_order: 7
 ---
 
 

--- a/docs/ha_ble.md
+++ b/docs/ha_ble.md
@@ -1,0 +1,52 @@
+---
+layout: default
+title: DIY sensors
+has_children: false
+has_toc: false
+permalink: ha_ble
+nav_order: 6
+---
+
+
+## DIY sensors (HA BLE)
+
+
+### Introduction
+
+BLE monitor has created support for your own DIY sensors, by introducing our own BLE format that can be read by BLE monitor, called `HA BLE`. The format is following the official Bluetooth GATT Characteristic and Object Type, which can be found on page 13 and further in this document: https://btprodspecificationrefs.blob.core.windows.net/assigned-values/16-bit%20UUID%20Numbers%20Document.pdf
+
+The data format of each property is defined in the GATT specification supplement: https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=524815. At the moment, the following sensors are supported. If you want another sensor, let us know by creating a new issue on Github. 
+
+| Object id | Property    | Data type        | Factor | example | result | Unit in HA |
+| --------- | ----------- | ---------------- | ------------- | ------------- | ------------- | ------------- |
+| `0x2A19`  | battery     | uint8 (1 byte)   | 1    | `0416192A59` | 89 | `%` |
+| `0x2A6D`  | pressure    | uint32 (4 bytes) | 0.001| `07166D2A78091000` | 1051.0 | `hPa` |
+| `0x2A6E`  | temperature | sint16 (2 bytes) | 0.01 | `05166E2A3409` | 23.56 | `°C`  | 
+| `0x2A6F`  | humidity    | uint16 (2 bytes) | 0.01 | `05166F2A5419` | 64.84 | `%` | 
+| `0x2A7B`  | dewpoint    | sint8 (1 byte)   | 1    | `04167b2a18` | 24 | `°C` | 
+| `0x2A98`  | weight      | struct (1 byte, flag)) +| bit 0 of flag = 0 = 0.005 | `0616982A00AA33` | 66.13 | `kg` (bit 0 of flag = 0) | 
+|           |             | uint16 (2 bytes, weight)| bit 0 of flag = 1 = 0.01 | `0616982A01AA33` | 132.26 | `lbs` (bit 0 of flag = 1) | 
+| `0X2AF2`  | energy      | uint32 (4 bytes) | 0.001| `0716F22A81121000` | 1053.313 | `kWh` | 
+| `0X2AFB`  | illuminance | uint24 (3 bytes) | 0.01 | `0616FB2A34AA00` | 435.72 | `lux`  | 
+| `0x2B05`  | power       | uint24 (3 bytes) | 0.1  | `052B510A00` | 264.1 | `W` | 
+| `0x2B18`  | voltage     | uint16 (2 bytes) | 1/64 | `0516182BB400` | 2.8125 | `V` | 
+| `0x2BD6`  | pm2.5       | SFLOAT (2 bytes) | 1    | `0516D62BD204` | 1234 | `kg/m3` |
+| `0x2BD7`  | pm10        | SFLOAT (2 bytes) | 1    | `0516D72BAB01`| 427 | `kg/m3` |
+|           |             |  |  |  | |  |
+| `0x2A4D`  | packet id   | uint8 (1 byte)   | 1    | `04164D2A09` | 9 |  |
+
+### Payload format
+
+BLE advertisements must contain `070848415f424c45`, which means `shortened local name` = `HA_BLE`. This will make sure BLE monitor recognizes the packet. The packet id is optional (see below). The payload has to contain at least one of the above measurements. It is allowed to have multiple measurements (e.g. temperature and humidity) in one BLE advertisment. However, the data must follow the above format. 
+
+Full example payloads are given in the [test_ha_ble.py](https://github.com/custom-components/ble_monitor/blob/HA-BLE/custom_components/ble_monitor/test/test_ha_ble.py) file. 
+
+### packet id
+
+The `packet id` is optional and is used to filter duplicate data. This allows you to send multiple advertisements that are exactly the same, to improve the chance that the advertisement arrives. BLE monitor will only process the advertisement if the `packet id` is different compared to the previous one. The `packet id` is a value between 0 (`0x00`) and 255 (`0xFF`), and should be increased on every change in data. 
+
+### Instructions to create a sensor in HA (temporary workaround)
+
+At the moment, a temperature sensor is added in [const.py](https://github.com/custom-components/ble_monitor/blob/30784951e9e80917ea2c1281fdf947d79ce260d0/custom_components/ble_monitor/const.py#L860) manually. You can change it to your needs by changing this line in const.py to the sensor you want (all sensors from the above table should work). 
+
+**This has to be done manually at the moment and will be lost during each update of BLE monitor. ** In a future update, we will change this such that it will automatically add the correct sensor(s), based on the data received. 


### PR DESCRIPTION
**Add parser for DIY sensors**

The format is following the official Bluetooth GATT Characteristic and Object Type, which can be found on page 13 and further in this document: https://btprodspecificationrefs.blob.core.windows.net/assigned-values/16-bit%20UUID%20Numbers%20Document.pdf

The data format is also defined in the GATT specification supplement: https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=524815

Currently implemented formats (table is WIP)

| Object id  | Property | Data type| Factor | example | result | Unit in HA |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| `0x2A19` | battery | uint8 (1 byte) | 1  | `0416192A59` | 89 | `%` |
| `0x2A6D` | pressure | uint32 (4 bytes) | 0.001  | `07166D2A78091000` | 1051.0 | `hPa` |
| `0x2A6E` | temperature | sint16 (2 bytes) | 0.01  | `05166E2A3409` | 23.56 | `°C`  | 
| `0x2A6F` | humidity | uint16 (2 bytes) | 0.01  | `05166F2A5419` | 64.84 | `%` | 
| `0x2A7B` | dewpoint | sint8 (1 byte) | 1  |`04167b2a18` | 24 | `°C` | 
| `0x2A98` | weight | struct (1 byte, flag)) + | bit 0 of flag = 0 = 0.005 | `0616982A00AA33` | 66.13 | `kg` (bit 0 of flag = 0) | 
|  |  | uint16 (2 bytes, weight) | bit 0 of flag = 1 = 0.01 | `0616982A01AA33` | 132.26 | `lbs` (bit 0 of flag = 1) | 
| `0X2AF2` | energy  | uint32 (4 bytes) | 0.001 | `0716F22A81121000` | 1053.313 | `kWh` | 
| `0X2AFB` | illuminance  | uint24 (3 bytes) | 0.01 |`0616FB2A34AA00` | 435.72 | `lux`  | 
| `0x2B05` | power  | uint24 (3 bytes) | 0.1 | `052B510A00` | 264.1 | `W` | 
| `0x2B18` | voltage  | uint16 (2 bytes) | 1/64 |`0516182BB400` | 2.8125 | `V` | 
| `0x2BD6` | pm2.5  | SFLOAT (2 bytes) | 1 | `0516D62BD204` | 1234 | `kg/m3` |
| `0x2BD7` | pm10  | SFLOAT (2 bytes) | 1 | `0516D72BAB01`| 427 | `kg/m3` |
|  |  |  |  |  | |  |
| `0x2A4D` | packet id | uint8 (1 byte) | 1  | `04164D2A09` | 9 |  |

**packet id**
The `packet id` is optional and can be used to filter duplicate data. This allows you to send multiple advertisements that are exactly the same, to improve the chance that the advertisement arrives. BLE monitor will only process the advertisement if the `packet id` is different compared to the previous one. The `packet id` is a value between 0 (`0x00`) and 255 (`0xFF`)

**To Do**
- [ ] add sensors automatically, based on the received sensor type. 

**Testing**
The current version hasn't been released as final or beta yet. You will have to manually change the files. A beta version will be released soon, allowing you to install it via HACS. 

**Instructions to create a sensor (temporary workaround)**
At the moment, I have added the temperature sensor to [const.py](https://github.com/custom-components/ble_monitor/blob/30784951e9e80917ea2c1281fdf947d79ce260d0/custom_components/ble_monitor/const.py#L860) manually, you can test it by changing this line in const.py to the sensor you want (all sensors from the above table should work). Some example payloads are given in the [test_ha_ble.py](https://github.com/custom-components/ble_monitor/blob/HA-BLE/custom_components/ble_monitor/test/test_ha_ble.py) file. In a future release, I will change this such that it automagically discovers the sensor type(s). 

BLE advertisements must contain `070848415f424c45`, which means `shortened local name` = `HA_BLE`

See also #689 