### PR TITLE
correct check for adapter LE capability

### DIFF
--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -314,7 +314,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                         "Bluetooth adapter with MAC address %s was not found. "
                         "It is therefore changed back to the default adapter. "
                         "Check the BLE monitor settings, if needed.",
-                        config[CONF_BT_INTERFACE]
+                        bt_mac
                     )
                     try:
                         default_hci = list(BT_INTERFACES.keys())[

--- a/custom_components/ble_monitor/bt_helpers.py
+++ b/custom_components/ble_monitor/bt_helpers.py
@@ -46,17 +46,13 @@ class MGMTBluetoothCtl:
         for idx in hci_idx_list:
             hci_info = btmgmt_sync.send('ReadControllerInformation', idx)
             _LOGGER.debug(hci_info)
-            #
-            # LE capability check disabled temporary until issue #709 is resolved
-            # it looks like LE capability state does not indicate the impossibility of LE scanning
-            #
-            # bt_le = hci_info.cmd_response_frame.current_settings.get(
-            #     btmgmt_protocol.SupportedSettings.LowEnergy
-            # )
-            # if bt_le is not True:
-            #     _LOGGER.warning("hci%i has no (or disabled) BT LE capabilities.", idx)
-            #     continue
-            #
+            ## bit 9 == LE capability (https://github.com/bluez/bluez/blob/master/doc/mgmt-api.txt)
+            bt_le = bool(
+                hci_info.cmd_response_frame.supported_settings & 0b000000001000000000
+            )
+            if bt_le is not True:
+                _LOGGER.warning("hci%i has no (or disabled) BT LE capabilities.", idx)
+                continue
             self.presented_list[idx] = hci_info.cmd_response_frame.address
             if hci == idx:
                 self.idx = idx

--- a/custom_components/ble_monitor/bt_helpers.py
+++ b/custom_components/ble_monitor/bt_helpers.py
@@ -46,12 +46,16 @@ class MGMTBluetoothCtl:
         for idx in hci_idx_list:
             hci_info = btmgmt_sync.send('ReadControllerInformation', idx)
             _LOGGER.debug(hci_info)
-            ## bit 9 == LE capability (https://github.com/bluez/bluez/blob/master/doc/mgmt-api.txt)
+            # bit 9 == LE capability (https://github.com/bluez/bluez/blob/master/doc/mgmt-api.txt)
             bt_le = bool(
                 hci_info.cmd_response_frame.supported_settings & 0b000000001000000000
             )
             if bt_le is not True:
-                _LOGGER.warning("hci%i has no (or disabled) BT LE capabilities.", idx)
+                _LOGGER.warning(
+                    "hci%i (%s) have no BT LE capabilities and will be ignored.",
+                    idx,
+                    hci_info.cmd_response_frame.address,
+                )
                 continue
             self.presented_list[idx] = hci_info.cmd_response_frame.address
             if hci == idx:


### PR DESCRIPTION
Inspired by #709
Had to make a new 7.6.1 urgent release with LE capability checking removed (as in the old bt_helpers) because the number of affected users could be large.

This pull request contains the correct LE capability check procedure and minor corrections to the log messages.
Tested with my old BT 2.0 adapter.

I am convinced that these changes can be safely included in the next release.