### PR TITLE
Add RSSI sensor to device tracker

### DIFF
--- a/custom_components/ble_monitor/ble_parser/__init__.py
+++ b/custom_components/ble_monitor/ble_parser/__init__.py
@@ -239,12 +239,22 @@ class BleParser:
         tracker_id = tracker_data['tracker_id'] if tracker_data and 'tracker_id' in tracker_data else mac
         if tracker_id in self.tracker_whitelist:
             if tracker_data is not None:
+                # AltBeacon and iBeacon trackers
                 tracker_data.update({"is connected": True})
             else:
                 tracker_data = {
                     "is connected": True,
                     "mac": ''.join('{:02X}'.format(x) for x in mac),
                     "rssi": rssi,
+                }
+            if sensor_data is None:
+                sensor_data = {
+                    "rssi": rssi,
+                    "mac": ''.join('{:02X}'.format(x) for x in mac),
+                    "type": "device tracker",
+                    "firmware": "Generic BLE tracker",
+                    "packet": "no packet id",
+                    "data": True,
                 }
         else:
             tracker_data = None

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     CONDUCTIVITY,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
-    ENTITY_CATEGORY_DIAGNOSTIC,
     LIGHT_LUX,
     MASS_KILOGRAMS,
     PERCENTAGE,
@@ -30,6 +29,7 @@ from homeassistant.const import (
     VOLUME_LITERS,
     Platform,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "ble_monitor"
 PLATFORMS = [
@@ -243,28 +243,6 @@ BINARY_SENSOR_TYPES: tuple[BLEMonitorBinarySensorEntityDescription, ...] = (
 
 SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
     BLEMonitorSensorEntityDescription(
-        key="mac",
-        sensor_class="StateChangedSensor",
-        name="ble mac",
-        unique_id="mac_",
-        icon="mdi:alpha-m-circle-outline",
-        native_unit_of_measurement=None,
-        device_class=None,
-        state_class=None,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    BLEMonitorSensorEntityDescription(
-        key="uuid",
-        sensor_class="StateChangedSensor",
-        name="ble uuid",
-        unique_id="uuid_",
-        icon="mdi:alpha-u-circle-outline",
-        native_unit_of_measurement=None,
-        device_class=None,
-        state_class=None,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    BLEMonitorSensorEntityDescription(
         key="temperature",
         sensor_class="TemperatureSensor",
         name="ble temperature",
@@ -446,7 +424,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
         key="measured power",
@@ -456,7 +434,49 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BLEMonitorSensorEntityDescription(
+        key="battery",
+        sensor_class="BatterySensor",
+        name="ble battery",
+        unique_id="batt_",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BLEMonitorSensorEntityDescription(
+        key="voltage",
+        sensor_class="MeasuringSensor",
+        name="ble voltage",
+        unique_id="v_",
+        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BLEMonitorSensorEntityDescription(
+        key="mac",
+        sensor_class="StateChangedSensor",
+        name="ble mac",
+        unique_id="mac_",
+        icon="mdi:alpha-m-circle-outline",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    BLEMonitorSensorEntityDescription(
+        key="uuid",
+        sensor_class="StateChangedSensor",
+        name="ble uuid",
+        unique_id="uuid_",
+        icon="mdi:alpha-u-circle-outline",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
         key="major",
@@ -467,7 +487,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         native_unit_of_measurement=None,
         device_class=None,
         state_class=None,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
         key="minor",
@@ -478,27 +498,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         native_unit_of_measurement=None,
         device_class=None,
         state_class=None,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    BLEMonitorSensorEntityDescription(
-        key="battery",
-        sensor_class="BatterySensor",
-        name="ble battery",
-        unique_id="batt_",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-    ),
-    BLEMonitorSensorEntityDescription(
-        key="voltage",
-        sensor_class="MeasuringSensor",
-        name="ble voltage",
-        unique_id="v_",
-        native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     BLEMonitorSensorEntityDescription(
         key="consumable",
@@ -858,6 +858,7 @@ MEASUREMENT_DICT = {
     'AltBeacon'               : [["rssi", "measured power"], ["uuid", "mac", "major", "minor"], []],  # mac can be dynamic
     'MyCO2'                   : [["temperature", "humidity", "co2", "rssi"], [], []],
     'HA BLE DIY'              : [["temperature", "rssi"], [], []],
+    'device tracker'          : [["rssi"], [], []],
 }
 
 
@@ -957,6 +958,7 @@ MANUFACTURER_DICT = {
     'iBeacon'                 : 'Apple',
     'AltBeacon'               : 'Radius Networks',
     'HA BLE DIY'              : 'Home Assistant DIY',
+    'device tracker'          : 'Generic BLE tracker',
 }
 
 # Renamed model dictionary
@@ -971,7 +973,6 @@ REPORT_UNKNOWN_LIST = [
     "BlueMaestro",
     "Brifit",
     "Govee",
-    "HA BLE",
     "Inkbird",
     "iNode",
     "iBeacon",

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.6.0",
+  "version": "7.7.0",
   "iot_class": "local_polling"
 }

--- a/docs/parse_data.md
+++ b/docs/parse_data.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Parse data from ESPHome
+title: Receive data from ESPHome (BLE Gateway)
 has_children: false
 has_toc: false
 permalink: parse_data
@@ -15,7 +15,7 @@ nav_order: 5
 
 BLE monitor has a service to parse BLE advertisements. This service can e.g. be used with ESPHome [BLE Gateway](https://github.com/myhomeiot/esphome-components#ble-gateway).
 
-You can also use this service to create support for you own home-brew sensor, as long as you make sure you follow the format of one of the existing sensors.
+You can also use this service to create support for you own home-brew sensor, as long as you make sure you follow our own [HA BLE](ha_ble) format (or the format of one of the other sensor brands).
 
 In this example you can see the BLE data packet from device with MAC address `A4:C1:38:B4:94:4C`, in the packet it's in reverse order `4C94B438C1A4`. The BLE packet should be in HCI format, with packet type HCI Event (0x04). The gateway id is optional and can e.g. be used to identify which ESPHome device did receive the message, which can be usefull for room localization.
 


### PR DESCRIPTION
- Adds an RSSI sensor to devices that are being tracked (#691)
- Fix for warning about deprecated use of `str based entity_category` in HA 2022.4