### PR TITLE
[BREAKING CHANGE] Use underscore in extra_state_attributes name

### DIFF
--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -48,23 +48,23 @@ _LOGGER = logging.getLogger(__name__)
 RESTORE_ATTRIBUTES = [
     "rssi",
     "firmware",
-    "last packet id",
+    "last_packet_id",
     ATTR_BATTERY_LEVEL,
     "status",
-    "motion timer",
+    "last_motion",
     "action",
     "method",
     "error",
-    "key id",
+    "key_id",
     "timestamp",
     "result",
     "counter",
     "score",
-    "toothbrush state",
+    "toothbrush_state",
     "pressure",
     "mode",
-    "sector timer",
-    "number of sectors",
+    "sector_timer",
+    "number_of_sectors",
 ]
 
 
@@ -101,7 +101,7 @@ class BLEupdaterBinary:
     async def async_run(self, hass):
         """Entities updater loop."""
 
-        async def async_add_binary_sensor(key, sensortype, firmware, manufacturer = None):
+        async def async_add_binary_sensor(key, sensortype, firmware, manufacturer=None):
             device_sensors = MEASUREMENT_DICT[sensortype][2]
             if key not in sensors_by_key:
                 sensors = []
@@ -237,7 +237,7 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
         devtype: str,
         firmware: str,
         description: BLEMonitorBinarySensorEntityDescription,
-        manufacturer = None
+        manufacturer=None
     ) -> None:
         """Initialize the binary sensor."""
         self.entity_description = description
@@ -257,13 +257,13 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
             else MANUFACTURER_DICT[devtype]
 
         self._extra_state_attributes = {
-            'sensor type': devtype,
-            'uuid' if self.is_beacon else 'mac address': self._fkey
+            'sensor_type': devtype,
+            'uuid' if self.is_beacon else 'mac_address': self._fkey
         }
 
         self.ready_for_update = False
-        self._restore_state = self._device_settings["restore state"]
-        self._reset_timer = self._device_settings["reset timer"]
+        self._restore_state = self._device_settings["restore_state"]
+        self._reset_timer = self._device_settings["reset_timer"]
         self._newstate = None
 
         self._attr_name = f"{description.name} {self._device_name}"
@@ -300,11 +300,11 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
             self._state = False
 
         restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac address' if self.is_beacon else 'uuid')
+        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
 
         for attr in restore_attr:
             if attr in old_state.attributes:
-                if attr in ['uuid', 'mac address']:
+                if attr in ['uuid', 'mac_address']:
                     self._extra_state_attributes[attr] = identifier_normalize(old_state.attributes[attr])
                     continue
 
@@ -366,19 +366,19 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
                         dev_reset_timer = device[CONF_DEVICE_RESET_TIMER]
         device_settings = {
             "name": dev_name,
-            "restore state": dev_restore_state,
-            "reset timer": dev_reset_timer,
+            "restore_state": dev_restore_state,
+            "reset_timer": dev_reset_timer,
         }
         _LOGGER.debug(
             "Binary sensor device with %s %s has the following settings. "
             "Name: %s. "
-            "Restore state: %s. "
+            "Restore State: %s. "
             "Reset Timer: %s",
             'uuid' if self.is_beacon else 'mac address',
             self._fkey,
             device_settings["name"],
-            device_settings["restore state"],
-            device_settings["reset timer"],
+            device_settings["restore_state"],
+            device_settings["reset_timer"],
         )
         return device_settings
 
@@ -387,10 +387,10 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
         if self.enabled is False:
             return
         self._newstate = data[self.entity_description.key]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["rssi"] = data["rssi"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
 
@@ -398,7 +398,7 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
             self._extra_state_attributes[ATTR_BATTERY_LEVEL] = batt_attr
         if "motion timer" in data:
             if data["motion timer"] == 1:
-                self._extra_state_attributes["last motion"] = dt_util.now()
+                self._extra_state_attributes["last_motion"] = dt_util.now()
         # dirty hack for kettle status
         if self._device_type in KETTLES:
             if self._newstate == 0:
@@ -417,26 +417,26 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
             self._extra_state_attributes["action"] = data["action"]
             self._extra_state_attributes["method"] = data["method"]
             self._extra_state_attributes["error"] = data["error"]
-            self._extra_state_attributes["key id"] = data["key id"]
+            self._extra_state_attributes["key_id"] = data["key id"]
             self._extra_state_attributes["timestamp"] = data["timestamp"]
         if self.entity_description.key == "fingerprint":
             self._extra_state_attributes["result"] = data["result"]
-            self._extra_state_attributes["key id"] = data["key id"]
+            self._extra_state_attributes["key_id"] = data["key id"]
         if self.entity_description.key == "toothbrush":
             if "counter" in data:
                 self._extra_state_attributes["counter"] = data["counter"]
             if "score" in data:
                 self._extra_state_attributes["score"] = data["score"]
             if "toothbrush state" in data:
-                self._extra_state_attributes["toothbrush state"] = data["toothbrush state"]
+                self._extra_state_attributes["toothbrush_state"] = data["toothbrush state"]
             if "pressure" in data:
                 self._extra_state_attributes["pressure"] = data["pressure"]
             if "mode" in data:
                 self._extra_state_attributes["mode"] = data["mode"]
             if "sector timer" in data:
-                self._extra_state_attributes["sector timer"] = data["sector timer"]
+                self._extra_state_attributes["sector_timer"] = data["sector timer"]
             if "number of sectors" in data:
-                self._extra_state_attributes["number of sectors"] = data["number of sectors"]
+                self._extra_state_attributes["number_of_sectors"] = data["number of sectors"]
 
     async def async_update(self):
         """Update sensor state and attribute."""
@@ -446,7 +446,7 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
 class MotionBinarySensor(BaseBinarySensor):
     """Representation of a Motion Binary Sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._start_timer = None
@@ -463,9 +463,9 @@ class MotionBinarySensor(BaseBinarySensor):
         # check if the reset timer is enabled
         if self._reset_timer > 0:
             try:
-                # if there is a last motion attribute, check the timer
+                # if there is a last_motion attribute, check the timer
                 now = dt_util.now()
-                self._start_timer = self._extra_state_attributes["last motion"]
+                self._start_timer = self._extra_state_attributes["last_motion"]
 
                 if now - self._start_timer >= timedelta(seconds=self._reset_timer):
                     self._state = False

--- a/custom_components/ble_monitor/device_tracker.py
+++ b/custom_components/ble_monitor/device_tracker.py
@@ -1,4 +1,4 @@
-"""Passive BLE monitor binary sensor platform."""
+"""Passive BLE monitor device tracker platform."""
 from datetime import timedelta
 import asyncio
 import logging
@@ -50,9 +50,9 @@ RESTORE_ATTRIBUTES = [
     CONF_GATEWAY_ID,
     'major',
     'minor',
-    'measured power',
-    'cypress temperature',
-    'cypress humidity'
+    'measured_power',
+    'cypress_temperature',
+    'cypress_humidity'
 ]
 
 
@@ -65,7 +65,7 @@ async def async_setup_platform(hass, conf, add_entities, discovery_info=None):
 
 
 async def async_setup_entry(hass, config_entry, add_entities):
-    """Set up the binary sensor platform."""
+    """Set up the device tracker platform."""
     _LOGGER.debug("Starting device tracker entry startup")
 
     blemonitor = hass.data[DOMAIN]["blemonitor"]
@@ -153,7 +153,7 @@ class BLEupdaterTracker:
                     data = None
                     continue
 
-                # schedule an immediate update of remote binary sensors
+                # schedule an immediate update of device tracker
                 if "is connected" in data:
                     entity = trackers[0]
                     entity.data_update(data)
@@ -211,18 +211,18 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
         if not old_state:
             self.ready_for_update = True
             return
-        if "last seen" in old_state.attributes:
-            self._last_seen = dt_util.parse_datetime(old_state.attributes["last seen"])
-            self._extra_state_attributes["last seen"] = dt_util.parse_datetime(
-                old_state.attributes["last seen"]
+        if "last_seen" in old_state.attributes:
+            self._last_seen = dt_util.parse_datetime(old_state.attributes["last_seen"])
+            self._extra_state_attributes["last_seen"] = dt_util.parse_datetime(
+                old_state.attributes["last_seen"]
             )
 
         restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac address' if self.is_beacon else 'uuid')
+        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
 
         for attr in restore_attr:
             if attr in old_state.attributes:
-                if attr in ['uuid', 'mac address']:
+                if attr in ['uuid', 'mac_address']:
                     self._extra_state_attributes[attr] = identifier_normalize(old_state.attributes[attr])
                     continue
 
@@ -283,8 +283,8 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
         if not self.is_beacon:
             return self._fkey
 
-        if 'mac address' in self._extra_state_attributes:
-            return self._extra_state_attributes['mac address']
+        if 'mac_address' in self._extra_state_attributes:
+            return self._extra_state_attributes['mac_address']
 
         return None
 
@@ -365,14 +365,14 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
                 self.ready_for_update = False
                 return
         self._last_seen = now
-        self._extra_state_attributes["last seen"] = self._last_seen
+        self._extra_state_attributes["last_seen"] = self._last_seen
         restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac address' if self.is_beacon else 'uuid')
+        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
 
         for attr in restore_attr:
-            key = CONF_MAC if attr == 'mac address' else attr
+            key = CONF_MAC if attr == 'mac_address' else attr
             if key in data:
-                if attr in ['uuid', 'mac address']:
+                if attr in ['uuid', 'mac_address']:
                     self._extra_state_attributes[attr] = identifier_normalize(data[key])
                     continue
 

--- a/custom_components/ble_monitor/sensor.py
+++ b/custom_components/ble_monitor/sensor.py
@@ -63,26 +63,26 @@ _LOGGER = logging.getLogger(__name__)
 RESTORE_ATTRIBUTES = [
     "median",
     "mean",
-    "last median of",
-    "last mean of",
+    "last_median_of",
+    "last_mean_of",
     "rssi",
     "firmware",
-    "last packet id",
-    "last button press",
-    "last remote button pressed",
-    "last type of press",
-    "dimmer value",
+    "last_packet_id",
+    "last_button_press",
+    "last_remote_button_pressed",
+    "last_type_o_press",
+    "dimmer_value",
     "constant",
-    "volume start",
-    "keg size",
-    "port name",
-    "port state",
-    "port index",
+    "volume_start",
+    "keg_size",
+    "port_name",
+    "port_state",
+    "port_index",
     "impedance",
-    "acceleration x",
-    "acceleration y",
-    "acceleration z",
-    "light level",
+    "acceleration_x",
+    "acceleration_y",
+    "acceleration_z",
+    "light_level",
     ATTR_BATTERY_LEVEL,
 ]
 
@@ -120,7 +120,7 @@ class BLEupdater:
     async def async_run(self, hass):
         """Entities updater loop."""
 
-        async def async_add_sensor(key, sensortype, firmware, manufacturer = None):
+        async def async_add_sensor(key, sensortype, firmware, manufacturer=None):
             averaging_sensors = MEASUREMENT_DICT[sensortype][0]
             instant_sensors = MEASUREMENT_DICT[sensortype][1]
             device_sensors = averaging_sensors + instant_sensors
@@ -234,8 +234,9 @@ class BLEupdater:
                         entity = sensors[device_sensors.index(measurement)]
                         entity.collect(data, period_cnt, batt_attr)
                         if (
-                            measurement in instant_sensors
-                            or ts_now - ts_restart < timedelta(seconds=self.period)
+                            measurement in instant_sensors or (
+                                ts_now - ts_restart < timedelta(seconds=self.period)
+                            )
                         ):
                             # instant measurements and measurements in the first period are updated instantly
                             if entity.pending_update is True:
@@ -338,7 +339,7 @@ class BaseSensor(RestoreEntity, SensorEntity):
         devtype: str,
         firmware: str,
         description: BLEMonitorSensorEntityDescription,
-        manufacturer = None,
+        manufacturer=None,
     ) -> None:
         """Initialize the sensor."""
         self.entity_description = description
@@ -357,15 +358,15 @@ class BaseSensor(RestoreEntity, SensorEntity):
             else MANUFACTURER_DICT[devtype]
 
         self._extra_state_attributes = {
-            'sensor type': devtype,
-            'uuid' if self.is_beacon else 'mac address': self._fkey
+            'sensor_type': devtype,
+            'uuid' if self.is_beacon else 'mac_address': self._fkey
         }
 
         self._measurements = []
         self.rssi_values = []
         self.pending_update = False
         self.ready_for_update = False
-        self._restore_state = self._device_settings["restore state"]
+        self._restore_state = self._device_settings["restore_state"]
         self._err = None
 
         self._attr_name = f"{description.name} {self._device_name}"
@@ -395,18 +396,14 @@ class BaseSensor(RestoreEntity, SensorEntity):
         if not old_state:
             self.ready_for_update = True
             return
-        try:
-            self._attr_native_unit_of_measurement = old_state.unit_of_measurement
-        except AttributeError:
-            pass
         self._state = old_state.state
 
         restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac address' if self.is_beacon else 'uuid')
+        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
 
         for attr in restore_attr:
             if attr in old_state.attributes:
-                if attr in ['uuid', 'mac address']:
+                if attr in ['uuid', 'mac_address']:
                     self._extra_state_attributes[attr] = identifier_normalize(old_state.attributes[attr])
                     continue
 
@@ -484,8 +481,8 @@ class BaseSensor(RestoreEntity, SensorEntity):
             "temperature unit": dev_temperature_unit,
             "decimals": dev_decimals,
             "use median": dev_use_median,
-            "restore state": dev_restore_state,
-            "reset timer": dev_reset_timer,
+            "restore_state": dev_restore_state,
+            "reset_timer": dev_reset_timer,
         }
         _LOGGER.debug(
             "Sensor device with %s %s has the following settings. "
@@ -495,14 +492,14 @@ class BaseSensor(RestoreEntity, SensorEntity):
             "Use Median: %s. "
             "Restore state: %s. "
             "Reset Timer: %s",
-            'uuid' if self.is_beacon else 'mac address',
+            'uuid' if self.is_beacon else 'mac_address',
             self._fkey,
             device_settings["name"],
             device_settings["temperature unit"],
             device_settings["decimals"],
             device_settings["use median"],
-            device_settings["restore state"],
-            device_settings["reset timer"],
+            device_settings["restore_state"],
+            device_settings["reset_timer"],
         )
         return device_settings
 
@@ -510,7 +507,7 @@ class BaseSensor(RestoreEntity, SensorEntity):
 class MeasuringSensor(BaseSensor):
     """Base class for measuring sensor entities."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._rdecimals = self._device_settings["decimals"]
@@ -525,10 +522,10 @@ class MeasuringSensor(BaseSensor):
             return
         self._period_cnt = period_cnt
         self._measurements.append(data[self.entity_description.key])
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
 
@@ -549,10 +546,10 @@ class MeasuringSensor(BaseSensor):
             state_median = round(sts.median(measurements), rdecimals)
             state_mean = round(sts.mean(measurements), rdecimals)
             if self._use_median:
-                textattr = "last median of"
+                textattr = "last_median_of"
                 self._state = state_median
             else:
-                textattr = "last mean of"
+                textattr = "last_mean_of"
                 self._state = state_mean
             self._extra_state_attributes[textattr] = len(measurements)
             self._extra_state_attributes["median"] = state_median
@@ -585,7 +582,7 @@ class MeasuringSensor(BaseSensor):
 class TemperatureSensor(MeasuringSensor):
     """Representation of a Temperature sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._attr_native_unit_of_measurement = self._device_settings["temperature unit"]
@@ -636,10 +633,10 @@ class TemperatureSensor(MeasuringSensor):
             self.pending_update = False
             return
         self._measurements.append(data[self.entity_description.key])
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if batt_attr is not None:
@@ -650,7 +647,7 @@ class TemperatureSensor(MeasuringSensor):
 class HumiditySensor(MeasuringSensor):
     """Representation of a Humidity sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._log_spikes = config[CONF_LOG_SPIKES]
@@ -684,10 +681,10 @@ class HumiditySensor(MeasuringSensor):
             self._measurements.append(int(data[self.entity_description.key]))
         else:
             self._measurements.append(data[self.entity_description.key])
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if batt_attr is not None:
@@ -698,7 +695,7 @@ class HumiditySensor(MeasuringSensor):
 class BatterySensor(MeasuringSensor):
     """Representation of a Battery sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
 
@@ -709,10 +706,10 @@ class BatterySensor(MeasuringSensor):
             return
         self._period_cnt = period_cnt
         self._state = data[self.entity_description.key]
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         self.pending_update = True
@@ -727,10 +724,10 @@ class BatterySensor(MeasuringSensor):
 class InstantUpdateSensor(BaseSensor):
     """Base class for instant updating sensor entity."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
-        self._reset_timer = self._device_settings["reset timer"]
+        self._reset_timer = self._device_settings["reset_timer"]
 
     def collect(self, data, period_cnt, batt_attr=None):
         """Measurements collector."""
@@ -742,10 +739,10 @@ class InstantUpdateSensor(BaseSensor):
             data[self.entity_description.key] = identifier_normalize(data[self.entity_description.key])
         self._state = data[self.entity_description.key]
 
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if batt_attr is not None:
@@ -758,10 +755,11 @@ class InstantUpdateSensor(BaseSensor):
         self.rssi_values.clear()
         self.pending_update = False
 
+
 class StateChangedSensor(InstantUpdateSensor):
     """Representation of a State changed sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
 
@@ -777,10 +775,11 @@ class StateChangedSensor(InstantUpdateSensor):
 
         super().collect(data, period_cnt, batt_attr)
 
+
 class AccelerationSensor(InstantUpdateSensor):
     """Representation of a Acceleration sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
 
@@ -790,13 +789,13 @@ class AccelerationSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = data[self.entity_description.key]
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes["acceleration x"] = data["acceleration x"]
-        self._extra_state_attributes["acceleration y"] = data["acceleration y"]
-        self._extra_state_attributes["acceleration z"] = data["acceleration z"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes["acceleration_x"] = data["acceleration x"]
+        self._extra_state_attributes["acceleration_y"] = data["acceleration y"]
+        self._extra_state_attributes["acceleration_z"] = data["acceleration z"]
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if batt_attr is not None:
@@ -807,7 +806,7 @@ class AccelerationSensor(InstantUpdateSensor):
 class WeightSensor(InstantUpdateSensor):
     """Representation of a Weight sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
 
@@ -817,9 +816,9 @@ class WeightSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = data[self.entity_description.key]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if self.entity_description.key == "non-stabilized weight":
@@ -842,7 +841,7 @@ class WeightSensor(InstantUpdateSensor):
 class EnergySensor(InstantUpdateSensor):
     """Representation of an Energy sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._rdecimals = self._device_settings["decimals"]
@@ -853,10 +852,10 @@ class EnergySensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = round(data[self.entity_description.key], self._rdecimals)
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if "energy unit" in data:
@@ -868,7 +867,7 @@ class EnergySensor(InstantUpdateSensor):
         if "constant" in data:
             self._extra_state_attributes["constant"] = data["constant"]
         if "light level" in data:
-            self._extra_state_attributes["light level"] = data["light level"]
+            self._extra_state_attributes["light_level"] = data["light level"]
         if batt_attr is not None:
             self._extra_state_attributes[ATTR_BATTERY_LEVEL] = batt_attr
         self.pending_update = True
@@ -877,7 +876,7 @@ class EnergySensor(InstantUpdateSensor):
 class PowerSensor(InstantUpdateSensor):
     """Representation of a Power sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._rdecimals = self._device_settings["decimals"]
@@ -888,10 +887,10 @@ class PowerSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = round(data[self.entity_description.key], self._rdecimals)
-        self._extra_state_attributes["sensor type"] = data["type"]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["sensor_type"] = data["type"]
+        self._extra_state_attributes["last_packet id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if "power unit" in data:
@@ -910,7 +909,7 @@ class PowerSensor(InstantUpdateSensor):
 class ButtonSensor(InstantUpdateSensor):
     """Representation of a Button sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
 
@@ -920,9 +919,9 @@ class ButtonSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = data[self.entity_description.key]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
         if batt_attr is not None:
@@ -947,7 +946,7 @@ class ButtonSensor(InstantUpdateSensor):
 class DimmerSensor(InstantUpdateSensor):
     """Representation of a Dimmer sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._button = "button"
@@ -959,13 +958,13 @@ class DimmerSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = data[self._button] + " " + str(data[self._dimmer]) + " steps"
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
-        self._extra_state_attributes["dimmer value"] = data[self._dimmer]
-        self._extra_state_attributes["last type of press"] = data[self._button]
+        self._extra_state_attributes["dimmer_value"] = data[self._dimmer]
+        self._extra_state_attributes["last_type_of_press"] = data[self._button]
         if batt_attr is not None:
             self._extra_state_attributes[ATTR_BATTERY_LEVEL] = batt_attr
         self.pending_update = True
@@ -988,7 +987,7 @@ class DimmerSensor(InstantUpdateSensor):
 class SwitchSensor(InstantUpdateSensor):
     """Representation of a Switch sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._button_switch = "button switch"
@@ -1004,12 +1003,12 @@ class SwitchSensor(InstantUpdateSensor):
         else:
             self.pending_update = False
             return
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
-        self._extra_state_attributes["last press"] = self._state
+        self._extra_state_attributes["last_press"] = self._state
         if batt_attr is not None:
             self._extra_state_attributes[ATTR_BATTERY_LEVEL] = batt_attr
         self.pending_update = True
@@ -1032,7 +1031,7 @@ class SwitchSensor(InstantUpdateSensor):
 class BaseRemoteSensor(InstantUpdateSensor):
     """Representation of a Remote sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
         self._button = "button"
@@ -1044,13 +1043,13 @@ class BaseRemoteSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = data[self._button] + " " + data[self._remote]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
-        self._extra_state_attributes["last remote button pressed"] = data[self._remote]
-        self._extra_state_attributes["last type of press"] = data["button"]
+        self._extra_state_attributes["last_remote_button_pressed"] = data[self._remote]
+        self._extra_state_attributes["last_type_of_press"] = data["button"]
         if batt_attr is not None:
             self._extra_state_attributes[ATTR_BATTERY_LEVEL] = batt_attr
         self.pending_update = True
@@ -1073,7 +1072,7 @@ class BaseRemoteSensor(InstantUpdateSensor):
 class VolumeDispensedSensor(InstantUpdateSensor):
     """Representation of a Kegtron Volume dispensed sensor."""
 
-    def __init__(self, config, key, devtype, firmware, description, manufacturer = None):
+    def __init__(self, config, key, devtype, firmware, description, manufacturer=None):
         """Initialize the sensor."""
         super().__init__(config, key, devtype, firmware, description, manufacturer)
 
@@ -1083,14 +1082,14 @@ class VolumeDispensedSensor(InstantUpdateSensor):
             self.pending_update = False
             return
         self._state = data[self.entity_description.key]
-        self._extra_state_attributes["last packet id"] = data["packet"]
+        self._extra_state_attributes["last_packet_id"] = data["packet"]
         self._extra_state_attributes["firmware"] = data["firmware"]
-        self._extra_state_attributes['mac address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
+        self._extra_state_attributes['mac_address' if self.is_beacon else 'uuid'] = dict_get_or_normalize(
             data, CONF_MAC, CONF_UUID
         )
-        self._extra_state_attributes["volume start"] = data["volume start"]
-        self._extra_state_attributes["keg size"] = data["keg size"]
-        self._extra_state_attributes["port name"] = data["port name"]
-        self._extra_state_attributes["port state"] = data["port state"]
-        self._extra_state_attributes["port index"] = data["port index"]
+        self._extra_state_attributes["volume_start"] = data["volume start"]
+        self._extra_state_attributes["keg_size"] = data["keg size"]
+        self._extra_state_attributes["port_name"] = data["port name"]
+        self._extra_state_attributes["port_state"] = data["port state"]
+        self._extra_state_attributes["port_index"] = data["port index"]
         self.pending_update = True


### PR DESCRIPTION
**BREAKING CHANGE**

`extra_state_attributes` should have underscores in stead of spaces in their name. In the UI, they will still be displayed without underscore. If you are using one of the sensors' attributes that contains a space (e.g. with a template sensor), you might have to update your configuration. Fix for #723 