### PR TITLE
Fix for CGPR1 battery spikes

### DIFF
--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.9.2-beta",
+  "version": "7.9.2",
   "iot_class": "local_polling"
 }

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.9.1-beta",
+  "version": "7.9.2-beta",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
- Fix for CGPR1 battery spikes (Fix for #559)

CGPR1 with XIAOMI firmware sends an "counter" as a battery reading, once per hour (every 6th or 7th battery measurement). This counter is increased with one every hour, but it messes up the battery readings. There is no way to tell that it not a battery reading, as it uses the object type "battery". 

The code will 
- create a list `batt_cgpr1` that has the last battery readings for CGPR1 sensors (max 5 values, FIFO)
- If the new battery measurement is the same as one of the numbers in the list, it will be used
- If not, the battery reading will be skipped (but still added to the list `batt_cgpr1` to be able to check the next reading).

This means that after a restart, at least two battery readings are needed, 
- If they are the same, the battery sensor and attributes are updated. 
- If not, it will add the reading to the list and will check the next measurement. 
- To limit the numbers in the list, it will pop the first one that has come in if the length of the list becomes larger than 5. 
