### PR TITLE
Disable HHCCJCY01 battery sensor

### DIFF
--- a/custom_components/ble_monitor/sensor.py
+++ b/custom_components/ble_monitor/sensor.py
@@ -460,6 +460,10 @@ class BaseSensor(RestoreEntity, SensorEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
+        if self.entity_description.key in ['battery']:
+            if self._device_type == "HHCCJCY01":
+                return False
+
         if not self.is_beacon:
             return True
 

--- a/docs/_devices/HHCCJCY01.md
+++ b/docs/_devices/HHCCJCY01.md
@@ -13,7 +13,7 @@ broadcasted_properties:
   - rssi
 broadcasted_property_notes:
   - property: battery
-    note: No battery info with firmware v3.2.1. Battery sensor is only supported when using [BLE gateway](https://github.com/myhomeiot/esphome-components) to forward the BLE advertisements with ESPHome to BLE monitor.
+    note: Battery sensor is disabled by default. HHCCJCY01 does not send battery info with firmware v3.2.1 and later. Battery sensor is only supported when using [BLE gateway](https://github.com/myhomeiot/esphome-components) to forward the BLE advertisements with ESPHome to BLE monitor. You can enable the `battery` sensor by going to `configuration`, `integrations`, select `devices` on the BLE monitor integration tile and select your device. Click on the `+1 disabled entity` to show the disabled sensor and select the disabled entity. Finally, click on `Enable entity` to enable it.
 broadcast_rate: ~1/min.
 active_scan:
 encryption_key:


### PR DESCRIPTION
This PR disables the battery sensor by default for (new) HHCCJCY01 MiFlora plant sensors. The battery sensor is only supported when forwarding the battery info with ESPHome in combination with BLE gateway. If you are using this, you can enable the sensor manually. Won't affect existing installations. 