### PR TITLE
Fix Oral-B

### DIFF
--- a/custom_components/ble_monitor/ble_parser/oral_b.py
+++ b/custom_components/ble_monitor/ble_parser/oral_b.py
@@ -48,19 +48,22 @@ def parse_oral_b(self, data, source_mac, rssi):
         else:
             result.update({"toothbrush": 0})
 
+        tb_state = STATES.get(state, "unknown state " + str(state))
+        tb_mode = MODES.get(mode, "unknown mode " + str(mode))
+
         if sector == 254:
-            sector = "last sector"
+            tb_sector = "last sector"
         elif sector == 255:
-            sector = "no sector"
+            tb_sector = "no sector"
         else:
-            sector = "sector " + str(sector)
+            tb_sector = "sector " + str(sector)
 
         result.update({
-            "toothbrush state": STATES[state],
+            "toothbrush state": tb_state,
             "pressure": pressure,
             "counter": counter,
-            "mode": MODES[mode],
-            "sector": sector,
+            "mode": tb_mode,
+            "sector": tb_sector,
             "sector timer": sector_timer,
             "number of sectors": no_of_sectors,
         })
@@ -82,7 +85,7 @@ def parse_oral_b(self, data, source_mac, rssi):
 
     result.update({
         "rssi": rssi,
-        "mac": ''.join('{:02X}'.format(x) for x in oral_b_mac[:]),
+        "mac": ''.join(f'{i:02X}' for i in oral_b_mac),
         "type": device_type,
         "packet": "no packet id",
         "firmware": firmware,
@@ -93,4 +96,4 @@ def parse_oral_b(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "7.9.6",
+  "version": "7.9.7",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
Fix for Oral-B when sending an non-defined state. 

States from 0-6 and 113-116 are known, what they represent. However, in #771 a state = `8` has been send by the toothbrush. The toothbrush will now set the state to "unknown state 8", instead of causing a `Fatal Error`. 

In case anyone knows the meaning of this state, let us know, such that we can add it. 