### PR TITLE
b-parasite: Fix parsing of negative temperatures, support protocol v2

### DIFF
--- a/custom_components/ble_monitor/ble_parser/bparasite.py
+++ b/custom_components/ble_monitor/ble_parser/bparasite.py
@@ -8,13 +8,13 @@ _LOGGER = logging.getLogger(__name__)
 def parse_bparasite(self, data, source_mac, rssi):
     """Check for adstruc length"""
     msg_length = len(data)
-    if msg_length == 22:  # TODO: Use version bits?
+    if msg_length == 22:  # TODO: Use protocol bits?
         bpara_mac = data[14:20]
         device_type = "b-parasite V1.1.0"
         firmware = "b-parasite V1.1.0 (with illuminance)"
-        (protocol, packet_id, batt, temp, humi, moist, mac, light) = unpack(">BBHHHH6sH", data[4:])
+        (protocol, packet_id, batt, temp, humi, moist, mac, light) = unpack(">BBHhHH6sH", data[4:])
         result = {
-            "temperature": temp / 1000,
+            "temperature": temp / (100 if (protocol >> 4) == 2 else 1000),
             "humidity": (humi / 65536) * 100,
             "voltage": batt / 1000.0,
             "moisture": (moist / 65536) * 100,
@@ -25,9 +25,9 @@ def parse_bparasite(self, data, source_mac, rssi):
         bpara_mac = data[14:20]
         device_type = "b-parasite V1.0.0"
         firmware = "b-parasite V1.0.0 (without illuminance)"
-        (protocol, packet_id, batt, temp, humi, moist, mac) = unpack(">BBHHHH6s", data[4:])
+        (protocol, packet_id, batt, temp, humi, moist, mac) = unpack(">BBHhHH6s", data[4:])
         result = {
-            "temperature": temp / 1000,
+            "temperature": temp / (100 if (protocol >> 4) == 2 else 1000),
             "humidity": (humi / 65536) * 100,
             "voltage": batt / 1000.0,
             "moisture": (moist / 65536) * 100,


### PR DESCRIPTION
This PR adds a fix for negative temperatures reported by b-parasites, which were treated as unsigned before, but are actually.
Also this adds support to protocol version 2 which increases the range of the temperature in exchange for (unnecessary) precision.

Another thought about the UUID used by both this device and the ATC firmware:
The packets from b-parasites include the MAC address of the device. Would it be a feasible solution to compare that MAC address (at a known location in the advertisement data) with the one provided from the bluetooth "receiver"? A known limitation is that macOS/iOS spoof the mac address which would lead to the packets not being decoded there, but otherwise it is the best solution for now, other than switching to a different UUID. Any thoughts?  