### PR TITLE
Add support for Laica Smart Scale (PS7011/PS7020) sensors

### DIFF
--- a/custom_components/ble_monitor/ble_parser/__init__.py
+++ b/custom_components/ble_monitor/ble_parser/__init__.py
@@ -16,6 +16,7 @@ from .inkbird import parse_inkbird
 from .inode import parse_inode
 from .jinou import parse_jinou
 from .kegtron import parse_kegtron
+from .laica import parse_laica
 from .miscale import parse_miscale
 from .moat import parse_moat
 from .oral_b import parse_oral_b
@@ -237,6 +238,10 @@ class BleParser:
                     elif comp_id == 0xFFFF and data_len == 0x1E:
                         # Kegtron
                         sensor_data = parse_kegtron(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0xA0AC and data_len == 0x0F and man_spec_data[14] in [0x06, 0x0D]:
+                        # Laica
+                        sensor_data = parse_laica(self, man_spec_data, mac, rssi)
                         break
 
                     # Filter on part of the UUID16

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -1017,6 +1017,7 @@ MEASUREMENT_DICT = {
     'Air Mentor Pro 2'        : [["temperature", "temperature calibrated", "humidity", "co2", "tvoc", "aqi", "air quality", "pm2.5", "pm10", "rssi"], [], []],
     'Meter TH S1'             : [["temperature", "humidity", "battery", "rssi"], [], []],
     'Meter TH plus'           : [["temperature", "humidity", "battery", "rssi"], [], []],
+    'Laica Smart Scale'       : [["weight", "impedance", "rssi"], [], []],
 }
 
 # Sensor manufacturer dictionary
@@ -1122,6 +1123,7 @@ MANUFACTURER_DICT = {
     'Air Mentor Pro 2'        : 'Air Mentor',
     'Meter TH S1'             : 'Switchbot',
     'Meter TH plus'           : 'Switchbot',
+    'Laica Smart Scale'       : 'Laica',
 }
 
 

--- a/custom_components/ble_monitor/test/test_laica.py
+++ b/custom_components/ble_monitor/test/test_laica.py
@@ -1,0 +1,21 @@
+"""The tests for the Mi Scale ble_parser."""
+from ble_monitor.ble_parser import BleParser
+
+
+class TestLaica:
+    """Tests for the Laica parser"""
+    def test_laica(self):
+        """Test Laica parser."""
+        data_string = "043e2b02010300a02bbe5e91a01f0201040303b0ff0fffaca0a02bbe5e91a0a02c92140dbf0709414141303032d9"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Laica Smart Scale"
+        assert sensor_msg["type"] == "Laica Smart Scale"
+        assert sensor_msg["mac"] == "A0:91:5E:BE:2B:A0"
+        assert sensor_msg["packet"] == "a02bbe5e91a0a02c92140dbf"
+        assert sensor_msg["data"]
+        assert sensor_msg["rssi"] == -65


### PR DESCRIPTION
Add support for these devices (but it might support other models too):
- [PS7022](https://www.laica.com/product/smart-electronic-scale-with-body-composition-calculator-ps7020/)
- [PS7011](https://www.laica.com/product/smart-electronic-scale-with-body-composition-calculator-ps7011/)

I think there are 3 other types of smart scales from Laica. I have the source code to read data from BLE advertisements, but I don't have the device to implement them.  

This is my first time adding a sensor so I might miss something. Please help me checking it. Also I don't know how to run the test 😄  A new document page about how to add a new sensor would be great.