### PR TITLE
Bug fixes: Oral-B (IO Series 7)

### DIFF
--- a/custom_components/ble_monitor/ble_parser/oral_b.py
+++ b/custom_components/ble_monitor/ble_parser/oral_b.py
@@ -12,6 +12,7 @@ STATES = {
     4: "charging",
     5: "setup",
     6: "flight menu",
+    8: "selection menu",
     113: "final test",
     114: "pcb test",
     115: "sleeping",

--- a/custom_components/ble_monitor/ble_parser/oral_b.py
+++ b/custom_components/ble_monitor/ble_parser/oral_b.py
@@ -19,18 +19,6 @@ STATES = {
     116: "transport"
 }
 
-MODES = {
-    0: "off",
-    1: "daily clean",
-    2: "sensitive",
-    3: "massage",
-    4: "whitening",
-    5: "deep clean",
-    6: "tongue cleaning",
-    7: "turbo",
-    255: "unknown"
-}
-
 PRESSURE = {
     114: "normal",
     118: "button pressed",
@@ -45,7 +33,6 @@ def parse_oral_b(self, data, source_mac, rssi):
     oral_b_mac = source_mac
     result = {"firmware": firmware}
     if msg_length == 15:
-        device_type = "SmartSeries 7000"
         (state, pressure, counter, mode, sector, sector_timer, no_of_sectors) = unpack(
             ">BBHBBBB", data[7:15]
         )
@@ -54,6 +41,33 @@ def parse_oral_b(self, data, source_mac, rssi):
             result.update({"toothbrush": 1})
         else:
             result.update({"toothbrush": 0})
+
+        device_type = "SmartSeries 7000"
+
+        firmware = data[4:7]
+        if firmware == b'\x062k':
+            firmware = "IO Series 7"
+            MODES = {
+                0: "daily clean",
+                1: "sensitive",
+                2: "gum care",
+                3: "whiten",
+                4: "intense",
+                8: "settings"
+            }
+        else:
+            firmware = "SmartSeries 7000"
+            MODES = {
+                0: "off",
+                1: "daily clean",
+                2: "sensitive",
+                3: "massage",
+                4: "whitening",
+                5: "deep clean",
+                6: "tongue cleaning",
+                7: "turbo",
+                255: "unknown"
+            }
 
         tb_state = STATES.get(state, "unknown state " + str(state))
         tb_mode = MODES.get(mode, "unknown mode " + str(mode))

--- a/custom_components/ble_monitor/ble_parser/oral_b.py
+++ b/custom_components/ble_monitor/ble_parser/oral_b.py
@@ -31,6 +31,12 @@ MODES = {
     255: "unknown"
 }
 
+PRESSURE = {
+    114: "normal",
+    118: "button pressed",
+    178: "high"
+}
+
 
 def parse_oral_b(self, data, source_mac, rssi):
     """Parser for Oral-B toothbrush."""
@@ -51,6 +57,7 @@ def parse_oral_b(self, data, source_mac, rssi):
 
         tb_state = STATES.get(state, "unknown state " + str(state))
         tb_mode = MODES.get(mode, "unknown mode " + str(mode))
+        tb_pressure = PRESSURE.get(pressure, "unknown pressure " + str(pressure))
 
         if sector == 254:
             tb_sector = "last sector"
@@ -61,7 +68,7 @@ def parse_oral_b(self, data, source_mac, rssi):
 
         result.update({
             "toothbrush state": tb_state,
-            "pressure": pressure,
+            "pressure": tb_pressure,
             "counter": counter,
             "mode": tb_mode,
             "sector": tb_sector,

--- a/custom_components/ble_monitor/ble_parser/oral_b.py
+++ b/custom_components/ble_monitor/ble_parser/oral_b.py
@@ -1,4 +1,4 @@
-"""Parser for Moat BLE advertisements."""
+"""Parser for Oral-B BLE advertisements."""
 import logging
 from struct import unpack
 
@@ -79,7 +79,7 @@ def parse_oral_b(self, data, source_mac, rssi):
     else:
         if self.report_unknown == "Oral-B":
             _LOGGER.info(
-                "BLE ADV from UNKNOWN Moat DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                "BLE ADV from UNKNOWN Oral-B DEVICE: RSSI: %s, MAC: %s, ADV: %s",
                 rssi,
                 to_mac(source_mac),
                 data.hex()


### PR DESCRIPTION
This change introduces a new way to map the "Modes" values based on the device model.

Support for the SmartSeries 7000 has been retained and support for the IO Series 7 has been added. It is likely that some mappings are missing for IO Series 8 & 9, however I do not have these devices on-hand.

The value for the model should really go into the dveice_type field, however this caused the whole plug-in to break for me (attributes stopped reporting). I instead placed the model into the "Firmware" field which worked and would've otherwise just been "Oral-B". The second issue with this is that we do not know the model until a broadcast is received.

Open to suggestions on ways to improve this commit as I am not a Home Assistant, BLE or Python expert by any stretch.