### PR TITLE
Add CO2 and tVOC measurements for DIY sensors

### DIFF
--- a/custom_components/ble_monitor/ble_parser/ha_ble.py
+++ b/custom_components/ble_monitor/ble_parser/ha_ble.py
@@ -79,6 +79,8 @@ DATA_MEAS_DICT = {
     0x0F: ["binary", 1],
     0x10: ["switch", 1],
     0x11: ["opening", 1],
+    0x12: ["co2", 1],
+    0x13: ["tvoc", 1],
 }
 
 

--- a/custom_components/ble_monitor/test/test_ha_ble.py
+++ b/custom_components/ble_monitor/test/test_ha_ble.py
@@ -269,3 +269,37 @@ class TestHaBle:
         assert sensor_msg["data"]
         assert sensor_msg["binary"] == 1
         assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_co2(self):
+        """Test HA BLE parser for co2 measurement"""
+        data_string = "043E1702010000A5808FE648540B02010607161C180312E204CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["co2"] == 1250
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_tvoc(self):
+        """Test HA BLE parser for tvoc measurement"""
+        data_string = "043E1702010000A5808FE648540B02010607161C1803133301CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["tvoc"] == 307
+        assert sensor_msg["rssi"] == -52

--- a/docs/ha_ble.md
+++ b/docs/ha_ble.md
@@ -105,7 +105,7 @@ At the moment, the following sensors are supported. A preferred data type is giv
 | `0x02`    | temperature | sint16 (2 bytes)    | 0.01   | `2302CA09`       | 25.06        | `°C`       |       |
 | `0x03`    | humidity    | uint16 (2 bytes)    | 0.01   | `0303BF13`       | 50.55        | `%`        |       |
 | `0x04`    | pressure    | uint24 (3 bytes)    | 0.01   | `0404138A01`     | 1008.83      | `hPa`      |       |
-| `0X05`    | illuminance | uint24 (3 bytes)    | 0.01   | `0405138A14`     | 13460.67     | `lux`      |       |
+| `0x05`    | illuminance | uint24 (3 bytes)    | 0.01   | `0405138A14`     | 13460.67     | `lux`      |       |
 | `0x06`    | weight      | uint16 (2 byte)     | 0.01   | `03065E1F`       | 80.3         | `kg`       | [2]   |
 | `0x07`    | weight unit | string (2 bytes)    | None   | `63076B67`       | "kg"         |            | [2]   |
 | `0x08`    | dewpoint    | sint16 (2 bytes)    | 0.01   | `2308CA06`       | 17.386       | `°C`       |       |
@@ -118,6 +118,8 @@ At the moment, the following sensors are supported. A preferred data type is giv
 | `0x0F`    | boolean     | uint8 (1 byte)      | 1      | `020F01`         | 1 (True)     | `True`     |       |
 | `0x10`    | switch      | uint8 (1 byte)      | 1      | `021001`         | 1 (True)     | `on`       |       |
 | `0x11`    | opening     | uint8 (1 byte)      | 1      | `021100`         | 0 (false)    | `closed`   |       |
+| `0x12`    | co2         | uint16 (2 bytes)    | 1      | `0312E204`       | 1250         | `ppm`      |       |
+| `0x13`    | tvoc        | uint16 (2 bytes)    | 1      | `03133301`       | 307          | `ug/m3`    |       |
 |           | mac         | 6 bytes (reversed)  |        | `86A6808FE64854` | 5448E68F80A6 |            | [3]   |
 
 


### PR DESCRIPTION
Hi!

I've added support for DIY air quality sensors:
- Reserved `HA BLE` Object IDs `0x12` and `0x13` for `co2` and `tvoc` measurements respectively
- Updated documentation

Entities are already described with correct measurement units:
- [CO2](https://github.com/custom-components/ble_monitor/blob/master/custom_components/ble_monitor/const.py#L553-L562)
- [tVOC](https://github.com/custom-components/ble_monitor/blob/master/custom_components/ble_monitor/const.py#L594-L603)

Hope I didn't miss anything. Please take a look
Thanks!