### PR TITLE
Fix govee H5182 and H5185

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -114,7 +114,7 @@ CONF_HMAX = 99.9
 
 # Sensors with deviating temperature range
 KETTLES = ('YM-K1501', 'YM-K1501EU', 'V-SK152')
-PROBES = ('iBBQ-2', 'iBBQ-4', 'iBBQ-6', 'H5183')
+PROBES = ('iBBQ-2', 'iBBQ-4', 'iBBQ-6', 'H5182', 'H5183', 'H5185')
 
 
 # Sensor entity description

--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -1142,6 +1142,7 @@ MANUFACTURER_DICT = {
     'H5178'                   : 'Govee',
     'H5178-outdoor'           : 'Govee',
     'H5179'                   : 'Govee',
+    'H5182'                   : 'Govee',
     'H5183'                   : 'Govee',
     'H5185'                   : 'Govee',
     'Ruuvitag'                : 'Ruuvitag',

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "8.9.5",
+  "version": "8.9.6",
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
- Fix for Govee H5182 not being added to Home Assistant
- Fix for Govee H5182 and H5185 to report temperatures above 60°C