### PR TITLE
Update M1S-T500.md

### DIFF
--- a/docs/_devices/M1S-T500.md
+++ b/docs/_devices/M1S-T500.md
@@ -17,6 +17,7 @@ broadcasted_property_notes:
     note: After starting the toothbrush, the counter will count the time you used your toothbrush
   - property: score
     note: After finishing toothbrushing, the toothbrush will report a score
+  - note: Needs to be setup & paired with Mi Home first time, else it will only send empty payload
 broadcast_rate:
 active_scan:
 encryption_key:


### PR DESCRIPTION
If the device is not setup with mi home app first it will only setup empty pay load and it is hard to troubleshoot this if there is no logs connected to this