### PR TITLE
Use UUID for Jaalee and better temperature and humidity definitions

### DIFF
--- a/custom_components/ble_monitor/ble_parser/__init__.py
+++ b/custom_components/ble_monitor/ble_parser/__init__.py
@@ -205,9 +205,12 @@ class BleParser:
                         sensor_data = parse_relsib(self, service_data, mac, rssi)
                         break
                     elif uuid16 == 0xF525:
-                        # UUID16 = Jaalee
-                        sensor_data = parse_jaalee(self, service_data, mac, rssi)
-                        break
+                        # UUID16 = Jaalee (also contains iBeacon manufacturer specific data)
+                        if man_spec_data_list:
+                            sensor_data, tracker_data = parse_jaalee(
+                                self, service_data, man_spec_data_list[0], mac, rssi
+                            )
+                            break
                     elif uuid16 == 0xFCD2:
                         # UUID16 = Allterco Robotics ltd (BTHome V2)
                         sensor_data = parse_bthome(self, service_data, uuid16, mac, rssi)

--- a/custom_components/ble_monitor/ble_parser/jaalee.py
+++ b/custom_components/ble_monitor/ble_parser/jaalee.py
@@ -2,38 +2,61 @@
 import logging
 from struct import unpack
 
+from .const import (
+    CONF_MAC,
+    CONF_TYPE,
+    CONF_PACKET,
+    CONF_FIRMWARE,
+    CONF_DATA,
+    CONF_RSSI,
+    CONF_UUID,
+    CONF_TRACKER_ID,
+    CONF_MAJOR,
+    CONF_MINOR,
+    CONF_MEASURED_POWER,
+)
 from .helpers import (
     to_mac,
+    to_uuid,
     to_unformatted_mac,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def parse_jaalee(self, data, source_mac, rssi):
+def parse_jaalee(self, data, ibeacon_data, source_mac, rssi):
     """Jaalee parser"""
     msg_length = len(data)
-    firmware = "Jaalee"
-    result = {"firmware": firmware}
     if msg_length == 15:
-        device_type = "JHT"
-        batt = data[4]
-        jaalee_mac_reversed = data[5:11]
-        jaalee_mac = jaalee_mac_reversed[::-1]
-        if jaalee_mac != source_mac:
-            _LOGGER.debug("Jaalee MAC address doesn't match data MAC address. Data: %s", data.hex())
-            return None
-        (temp, humi) = unpack(">HH", data[11:])
-        temp = round(0.0026821682 * temp - 46.873, 2)
-        humi = round(0.0019213762 * humi - 6.332, 2)
+        # iBeacon data
+        uuid = ibeacon_data[6:22]
+        (major, minor, power) = unpack(">HHb", ibeacon_data[22:27])
 
-        result.update(
-            {
-                "temperature": temp,
-                "humidity": humi,
-                "battery": batt
-            }
-        )
+        tracker_data = {
+            CONF_RSSI: rssi,
+            CONF_MAC: to_unformatted_mac(source_mac),
+            CONF_UUID: to_uuid(uuid).replace('-', ''),
+            CONF_TRACKER_ID: uuid,
+            CONF_MAJOR: major,
+            CONF_MINOR: minor,
+            CONF_MEASURED_POWER: power,
+        }
+
+        # Jaalee service data
+        batt = data[4]
+        (temp, humi) = unpack(">HH", data[11:])
+        # data follows the iBeacon temperature and humidity definition
+        temp = round(175.72 * temp / 65536 - 46.85, 2)
+        humi = round(125.0 * humi / 65536 - 6, 2)
+        sensor_data = {
+            CONF_TYPE: "JHT",
+            CONF_PACKET: "no packet id",
+            CONF_FIRMWARE: "Jaalee",
+            CONF_DATA: True,
+            "temperature": temp,
+            "humidity": humi,
+            "battery": batt
+        } | tracker_data
     else:
         if self.report_unknown == "Jaalee":
             _LOGGER.info(
@@ -42,19 +65,12 @@ def parse_jaalee(self, data, source_mac, rssi):
                 to_mac(source_mac),
                 data.hex()
             )
-        return None
+        return None, None
 
-    # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and jaalee_mac.lower() not in self.sensor_whitelist:
-        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(jaalee_mac))
-        return None
+    # check for UUID presence in sensor whitelist, if needed
+    if self.discovery is False and uuid and uuid not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. UUID: %s is not whitelisted!", to_uuid(uuid))
 
-    result.update({
-        "rssi": rssi,
-        "mac": to_unformatted_mac(jaalee_mac),
-        "type": device_type,
-        "packet": "no packet id",
-        "firmware": firmware,
-        "data": True
-    })
-    return result
+        return None, None
+
+    return sensor_data, tracker_data

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "11.3.1",
+  "version": "11.3.2",
   "iot_class": "local_polling"
 }

--- a/custom_components/ble_monitor/test/test_jaalee
+++ b/custom_components/ble_monitor/test/test_jaalee
@@ -15,8 +15,9 @@ class TestJaalee:
         assert sensor_msg["firmware"] == "Jaalee"
         assert sensor_msg["type"] == "JHT"
         assert sensor_msg["mac"] == "D09FFF818513"
+        assert sensor_msg["uuid"] == "ebefd08370a247c89837e7b5634df525"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 7.41
-        assert sensor_msg["humidity"] == 38.08
+        assert sensor_msg["temperature"] == 7.42
+        assert sensor_msg["humidity"] == 38.06
         assert sensor_msg["rssi"] == -52


### PR DESCRIPTION
Jaalee uses a rotation MAC address and should thus be added based on the UUID, not the MAC address. 

- With this PR, Jaalee should use the UUID from the iBeacon data 
- Also improved the temperature and humidity definitions, as they turn out to follow the same definition as the iBeacon temperature and humidity. 