### PR TITLE
Fix the type hint of to_unformatted_mac() helper

### DIFF
--- a/custom_components/ble_monitor/ble_parser/helpers.py
+++ b/custom_components/ble_monitor/ble_parser/helpers.py
@@ -12,6 +12,6 @@ def to_mac(addr: str) -> str:
     return ':'.join(f'{i:02X}' for i in addr)
 
 
-def to_unformatted_mac(addr: int):
+def to_unformatted_mac(addr: str) -> str:
     """Return unformatted MAC address"""
     return ''.join(f'{i:02X}' for i in addr[:])


### PR DESCRIPTION
I think it should be `str` not `int`. 

