### PR TITLE
Use iBeacon adv for jaalee

### DIFF
--- a/custom_components/ble_monitor/ble_parser/__init__.py
+++ b/custom_components/ble_monitor/ble_parser/__init__.py
@@ -274,7 +274,8 @@ class BleParser:
                             sensor_data, tracker_data = parse_tilt(self, man_spec_data, mac, rssi)
                             break
                         elif int.from_bytes(man_spec_data[6:22], byteorder='big') in JAALEE_TYPES:
-                            # skip Jaalee iBeacon messages, as they don't have a unique uuid
+                            # Jaalee
+                            sensor_data = parse_jaalee(self, man_spec_data, mac, rssi)
                             break
                         else:
                             # iBeacon

--- a/custom_components/ble_monitor/ble_parser/jaalee.py
+++ b/custom_components/ble_monitor/ble_parser/jaalee.py
@@ -15,7 +15,22 @@ def parse_jaalee(self, data, source_mac, rssi):
     msg_length = len(data)
     firmware = "Jaalee"
     result = {"firmware": firmware}
-    if msg_length == 15:
+    if msg_length == 28 and data[1:4] == b'\xff\x4c\x00' and data[20:22] == b'\xf5\x25':
+        device_type = "JHT"
+        jaalee_mac = source_mac
+        (temp, humi, _, batt) = unpack(">HHBB", data[22:])
+        # data follows the iBeacon temperature and humidity definition
+        temp = round(175.72 * temp / 65536 - 46.85, 2)
+        humi = round(125.0 * humi / 65536 - 6, 2)
+
+        result.update(
+            {
+                "temperature": temp,
+                "humidity": humi,
+                "battery": batt
+            }
+        )
+    elif msg_length == 15:
         device_type = "JHT"
         batt = data[4]
         jaalee_mac_reversed = data[5:11]

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": [],
   "codeowners": ["@Ernst79", "@Magalex2x14", "@Thrilleratplay"],
-  "version": "11.4.0",
+  "version": "11.4.1",
   "iot_class": "local_polling"
 }

--- a/custom_components/ble_monitor/test/test_jaalee.py
+++ b/custom_components/ble_monitor/test/test_jaalee.py
@@ -29,5 +29,13 @@ class TestJaalee:
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
-        assert sensor_msg is None
+        assert sensor_msg["firmware"] == "Jaalee"
+        assert sensor_msg["type"] == "JHT"
+        assert sensor_msg["mac"] == "D2F3B4CD1E4B"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 32.86
+        assert sensor_msg["humidity"] == 37.51
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["rssi"] == -41
         assert tracker_msg is None


### PR DESCRIPTION
Changed the Jaalee parser to also use the iBeacon messages for temperature and humidity measurements. 