### PR TITLE
enhancement #913: Updated 'get_beacon_key.py' to use bleak instead of bluepy

### DIFF
--- a/custom_components/ble_monitor/ble_parser/get_beacon_key.py
+++ b/custom_components/ble_monitor/ble_parser/get_beacon_key.py
@@ -107,15 +107,14 @@ async def get_beacon_key(mac, product_id):
         # (use 'python service_explorer.py --address <MAC> --service fe95' to dump the 'Xiaomi Inc.' service)
         for service in client.services:
             for char in service.characteristics:
-                match char.description:
-                    case 'token':
-                        HANDLE_AUTH = char.handle
-                    case 'Version':
-                        HANDLE_FIRMWARE_VERSION = char.handle
-                    case 'Authentication':
-                        HANDLE_AUTH_INIT = char.handle
-                    case 'beacon_key':
-                        HANDLE_BEACON_KEY = char.handle
+                if (char.description == 'token'):
+                    HANDLE_AUTH = char.handle
+                elif (char.description == 'Version'):
+                    HANDLE_FIRMWARE_VERSION = char.handle
+                elif (char.description == 'Authentication'):
+                    HANDLE_AUTH_INIT = char.handle
+                elif (char.description == 'beacon_key'):
+                    HANDLE_BEACON_KEY = char.handle
 
         # An asyncio future object is needed for callback handling
         future = asyncio.get_event_loop().create_future()

--- a/custom_components/ble_monitor/ble_parser/get_beacon_key.py
+++ b/custom_components/ble_monitor/ble_parser/get_beacon_key.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Usage:
-#   pip3 install bluepy
+#   pip3 install bleak asyncio
 #   python3 get_beacon_key.py <MAC> <PRODUCT_ID>
 #
 # List of PRODUCT_ID:
@@ -14,20 +14,18 @@
 # Example:
 #   python3 get_beacon_key.py AB:CD:EF:12:34:56 950
 
+import asyncio
 import random
 import re
 import sys
 
-from bluepy.btle import UUID, DefaultDelegate, Peripheral
+from bleak import BleakClient, BleakScanner
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.uuids import normalize_uuid_16
 
 MAC_PATTERN = r"^[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}$"
 
 UUID_SERVICE = "fe95"
-
-HANDLE_AUTH = 3
-HANDLE_FIRMWARE_VERSION = 10
-HANDLE_AUTH_INIT = 19
-HANDLE_BEACON_KEY = 25
 
 MI_KEY1 = bytes([0x90, 0xCA, 0x85, 0xDE])
 MI_KEY2 = bytes([0x92, 0xAB, 0x54, 0xFA])
@@ -94,7 +92,7 @@ def generateRandomToken() -> bytes:
     return token
 
 
-def get_beacon_key(mac, product_id):
+async def get_beacon_key(mac, product_id):
     reversed_mac = reverseMac(mac)
     token = generateRandomToken()
 
@@ -103,29 +101,67 @@ def get_beacon_key(mac, product_id):
 
     # Connect
     print("Connection in progress...")
-    peripheral = Peripheral(deviceAddr=mac)
-    print("Successful connection!")
+    async with BleakClient(mac, services=[UUID_SERVICE]) as client:
+        print("Successful connection!")
 
-    # Auth (More information: https://github.com/archaron/docs/blob/master/BLE/ylkg08y.md)
-    print("Authentication in progress...")
-    auth_service = peripheral.getServiceByUUID(UUID_SERVICE)
-    auth_descriptors = auth_service.getDescriptors()
-    peripheral.writeCharacteristic(HANDLE_AUTH_INIT, MI_KEY1, "true")
-    auth_descriptors[1].write(SUBSCRIBE_TRUE, "true")
-    peripheral.writeCharacteristic(HANDLE_AUTH, cipher(mixA(reversed_mac, product_id), token), "true")
-    peripheral.waitForNotifications(10.0)
-    peripheral.writeCharacteristic(3, cipher(token, MI_KEY2), "true")
-    print("Successful authentication!")
+        # Map the characteristics name to the handle ids (uuids won't work)
+        # The service explorer from https://github.com/hbldh/bleak/blob/master/examples/service_explorer.py shows the characteristics
+        # (use 'python service_explorer.py --address <MAC> --service fe95' to dump the 'Xiaomi Inc.' service)
+        for service in client.services:
+            for char in service.characteristics:
+                match char.description:
+                    case 'token':
+                        HANDLE_AUTH = char.handle
+                    case 'Version':
+                        HANDLE_FIRMWARE_VERSION = char.handle
+                    case 'Authentication':
+                        HANDLE_AUTH_INIT = char.handle
+                    case 'beacon_key':
+                        HANDLE_BEACON_KEY = char.handle
 
-    # Read
-    beacon_key = cipher(token, peripheral.readCharacteristic(HANDLE_BEACON_KEY)).hex()
-    firmware_version = cipher(token, peripheral.readCharacteristic(HANDLE_FIRMWARE_VERSION)).decode()
+        # An asyncio future object is needed for callback handling
+        future = asyncio.get_event_loop().create_future()
 
-    print(f"beaconKey: '{beacon_key}'")
-    print(f"firmware_version: '{firmware_version}'")
+        # Auth (More information: https://github.com/archaron/docs/blob/master/BLE/ylkg08y.md)
+        print("Authentication in progress...")
+
+        # Send 0x90, 0xCA, 0x85, 0xDE bytes to authInitCharacteristic.
+        await client.write_gatt_char(HANDLE_AUTH_INIT, MI_KEY1, True)
+        # Subscribe authCharacteristic.
+        # (a lambda callback is used to set the futures result on the notification event)
+        await client.start_notify(HANDLE_AUTH, lambda _, data: future.set_result(data))
+        # Send cipher(mixA(reversedMac, productID), token) to authCharacteristic.
+        await client.write_gatt_char(HANDLE_AUTH, cipher(mixA(reversed_mac, product_id), token), True)
+        # Now you'll get a notification on authCharacteristic. You must wait for this notification before proceeding to next step
+        await asyncio.wait_for(future, 10.0)
+
+        # The notification data can be ignored or used to check an integrity, this is optional
+        print(f"notifyData:  '{future.result().hex()}'")
+        # If you want to perform a check, compare cipher(mixB(reversedMac, productID), cipher(mixA(reversedMac, productID), res))
+        # where res is received payload ...
+        print(f"cipheredRes: '{cipher(mixB(reversed_mac, product_id), cipher(mixA(reversed_mac, product_id), future.result())).hex()}'")
+        # ... with your token, they must equal.
+        print(f"randomToken: '{token.hex()}'")
+
+        # Send 0x92, 0xAB, 0x54, 0xFA to authCharacteristic.
+        await client.write_gatt_char(HANDLE_AUTH, cipher(token, MI_KEY2), True)
+        print("Successful authentication!")
+
+        # Read
+        beacon_key = cipher(token, await client.read_gatt_char(HANDLE_BEACON_KEY)).hex()
+        # Read from verCharacteristics. You can ignore the response data, you just have to perform a read to complete authentication process.
+        # If the data is used, it will show the firmware version
+        firmware_version = cipher(token, await client.read_gatt_char(HANDLE_FIRMWARE_VERSION)).decode()
+
+        print(f"beaconKey: '{beacon_key}'")
+        print(f"firmware_version: '{firmware_version}'")
+
+        # Device will disconnect when block exits.
+        print("Disconnection in progress...")
+    print("Disconnected!")
 
 
-def main(argv):
+async def main(argv):
     # ARGS
     if len(argv) <= 2:
         print("usage: get_beacon_key.py <MAC> <PRODUCT_ID>\n")
@@ -152,8 +188,8 @@ def main(argv):
         return
 
     # BEACON_KEY
-    get_beacon_key(mac, product_id)
+    await get_beacon_key(mac, product_id)
 
 
 if __name__ == '__main__':
-    main(sys.argv)
+    asyncio.run(main(sys.argv))

--- a/custom_components/ble_monitor/ble_parser/get_beacon_key.py
+++ b/custom_components/ble_monitor/ble_parser/get_beacon_key.py
@@ -19,9 +19,7 @@ import random
 import re
 import sys
 
-from bleak import BleakClient, BleakScanner
-from bleak.backends.characteristic import BleakGATTCharacteristic
-from bleak.uuids import normalize_uuid_16
+from bleak import BleakClient
 
 MAC_PATTERN = r"^[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}$"
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -336,7 +336,7 @@ We have created a python script that will get the beaconkey by connecting to the
 ```
 wget https://raw.githubusercontent.com/custom-components/ble_monitor/master/custom_components/ble_monitor/ble_parser/get_beacon_key.py
 apt-get install python3-pip libglib2.0-dev
-pip3 install bluepy
+pip3 install bleak asyncio
 python3 get_beacon_key.py <MAC> <PRODUCT_ID>
 ```
 Replace `<MAC>` with your MAC address of the remote/dimmer and replace `<PRODUCT_ID>` with one of the following numbers, corresponding to your remote/dimmer.


### PR DESCRIPTION
When I tried to integrate a YLKG07YL device I got an error similar to the one mentioned in issue #1254:
```
pi@piberry:~/ble $ python3 ./get_beacon_key.py 12:34:56:78:90:AB 950
Activate pairing on your 'DC:97:58:39:D6:D7' device, then press Enter:
Connection in progress...
Successful connection!
Authentication in progress...
Traceback (most recent call last):
  File "/home/pi/ble/./get_beacon_key.py", line 159, in <module>
    main(sys.argv)
  File "/home/pi/ble/./get_beacon_key.py", line 155, in main
    get_beacon_key(mac, product_id)
  File "/home/pi/ble/./get_beacon_key.py", line 113, in get_beacon_key
    peripheral.writeCharacteristic(HANDLE_AUTH_INIT, MI_KEY1, "true")
  File "/home/pi/.local/lib/python3.9/site-packages/bluepy/btle.py", line 543, in writeCharacteristic
    return self._getResp('wr')
  File "/home/pi/.local/lib/python3.9/site-packages/bluepy/btle.py", line 407, in _getResp
    resp = self._waitResp(wantType + ['ntfy', 'ind'], timeout)
  File "/home/pi/.local/lib/python3.9/site-packages/bluepy/btle.py", line 368, in _waitResp
    raise BTLEGattError("Bluetooth command failed", resp)
bluepy.btle.BTLEGattError: Bluetooth command failed (code: 3, error: Attribute can't be written)
```
A little googling told me, that the `bluepy` stack is deprecated and buggy and thus I decided to use `bleak` instead, matching the suggestion made in the enhancement #913. The modified version of the script has been tested on a Windows 10 machine with Python 3.12.0 and on a raspberry pi using Raspbian GNU/Linux 11 (bullseye) with Python 3.9.2. It works for both my YLKG07YL dimmers.

This pull request contains the following changes:

- bleak and asyncio have to be installed and imported instead of bluepy.
- The different characteritics are adressed by their unique uuids because bleak uses diffrent handle ids.
- Obviously, the bluepy calls have been replaced by bleak calls.
- The callback notification has been implemented by some _asyncio future magic_ with timeout.
- I have added a number of comments to each authentication step (bluntly copied from https://github.com/archaron/docs/blob/master/BLE/ylkg08y.md).
- I have added the integrity check from the same documentation.
- Some `async` and `await` keyword have been added as well to support the asyncio API.