### PR TITLE
smartdry: fix parsing when some information is missing

### DIFF
--- a/custom_components/ble_monitor/ble_parser/smartdry.py
+++ b/custom_components/ble_monitor/ble_parser/smartdry.py
@@ -35,17 +35,21 @@ def parse_smartdry(self, data: bytes, mac: str):
         else:
             volt = None
 
-        if volt >= 3.00:
-            batt = 100
-        elif volt >= 2.60:
-            batt = 60 + (volt - 2.60) * 100
-        elif volt >= 2.50:
-            batt = 40 + (volt - 2.50) * 200
-        elif volt >= 2.45:
-            batt = 20 + (volt - 2.45) * 400
-        else:
-            batt = 0
-        if volt:
+        batt = None
+
+        if volt is not None:
+            if volt >= 3.00:
+                batt = 100
+            elif volt >= 2.60:
+                batt = 60 + (volt - 2.60) * 100
+            elif volt >= 2.50:
+                batt = 40 + (volt - 2.50) * 200
+            elif volt >= 2.45:
+                batt = 20 + (volt - 2.45) * 400
+            else:
+                batt = 0
+
+        if volt is not None:
             result.update({
                 "voltage": volt,
                 "battery": batt

--- a/custom_components/ble_monitor/ble_parser/smartdry.py
+++ b/custom_components/ble_monitor/ble_parser/smartdry.py
@@ -56,6 +56,7 @@ def parse_smartdry(self, data: bytes, mac: str):
             })
     else:
         device_type = None
+        firmware = None
     if device_type is None:
         if self.report_unknown == "SmartDry":
             _LOGGER.info(


### PR DESCRIPTION
Some messages from the SmartDry device may not contain all the necessary information. I spotted this error in my logs:
```
 File "/config/custom_components/ble_monitor/ble_parser/smartdry.py", line 38, in parse_smartdry
    if volt >= 3.00:
       ^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'NoneType' and 'float'
```

This makes sure `volt` is not `None` before doing any comparison operation (and also adds safeguards against `firmware`/`batt` not being set). 