### PR TITLE
remove direct refs to homeassistant.helpers

### DIFF
--- a/.github/workflows/test_commit.yml
+++ b/.github/workflows/test_commit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v5"
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt
       - name: Run pytest

--- a/custom_components/ble_monitor/__init__.py
+++ b/custom_components/ble_monitor/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.const import (CONF_DEVICES, CONF_DISCOVERY, CONF_MAC,
                                  CONF_UNIQUE_ID, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity_registry import async_entries_for_device
+from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.util import dt
 
 from .ble_parser import BleParser
@@ -400,20 +400,20 @@ async def async_cleanup_entries_service(hass: HomeAssistant, service_data):
     """Remove orphaned entries from device and entity registries."""
     _LOGGER.debug("async_cleanup_entries_service")
 
-    entity_registry = hass.helpers.entity_registry.async_get(hass)
-    device_registry = hass.helpers.device_registry.async_get(hass)
+    ent_registry = entity_registry.async_get(hass)
+    dev_registry = device_registry.async_get(hass)
     config_entry_id = hass.data[DOMAIN]["config_entry_id"]
 
     devices_to_be_removed = [
         entry.id
-        for entry in device_registry.devices.values()
+        for entry in dev_registry.devices.values()
         if config_entry_id in entry.config_entries
     ]
 
     # Remove devices that don't belong to any entity
     for device_id in devices_to_be_removed:
-        if len(async_entries_for_device(entity_registry, device_id)) == 0:
-            device_registry.async_remove_device(device_id)
+        if len(ent_registry.async_entries_for_device(ent_registry, device_id)) == 0:
+            dev_registry.async_remove_device(device_id)
             _LOGGER.debug("device %s will be deleted", device_id)
 
 

--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.const import (ATTR_BATTERY_LEVEL, CONF_DEVICES, CONF_MAC,
                                  CONF_NAME, CONF_UNIQUE_ID, STATE_OFF,
                                  STATE_ON)
+from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt
@@ -131,8 +132,8 @@ class BLEupdaterBinary:
 
         # Set up binary sensors of configured devices on startup when device model is available in device registry
         if self.config[CONF_DEVICES]:
-            dev_registry = hass.helpers.device_registry.async_get(hass)
-            ent_registry = hass.helpers.entity_registry.async_get(hass)
+            dev_registry = device_registry.async_get(hass)
+            ent_registry = entity_registry.async_get(hass)
             for device in self.config[CONF_DEVICES]:
                 # get device_model and firmware from device registry to setup binary sensor
                 key = dict_get_or(device)
@@ -149,7 +150,7 @@ class BLEupdaterBinary:
                     firmware = RENAMED_FIRMWARE_DICT.get(firmware, firmware)
                     manufacturer = RENAMED_MANUFACTURER_DICT.get(manufacturer, manufacturer)
                     # get all entities for this device
-                    entity_list = hass.helpers.entity_registry.async_entries_for_device(
+                    entity_list = entity_registry.async_entries_for_device(
                         registry=ent_registry, device_id=device_id, include_disabled_entities=False
                     )
                     # find the measurement key for each entity

--- a/custom_components/ble_monitor/manifest.json
+++ b/custom_components/ble_monitor/manifest.json
@@ -14,5 +14,5 @@
     "btsocket>=0.2.0",
     "pyric>=0.1.6.3"
   ],
-  "version": "12.10.4"
+  "version": "12.11.1-beta"
 }

--- a/custom_components/ble_monitor/sensor.py
+++ b/custom_components/ble_monitor/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import RestoreSensor, SensorEntity
 from homeassistant.const import (ATTR_BATTERY_LEVEL, CONF_DEVICES, CONF_MAC,
                                  CONF_NAME, CONF_TEMPERATURE_UNIT,
                                  CONF_UNIQUE_ID, UnitOfMass, UnitOfTemperature)
+from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt
@@ -140,8 +141,8 @@ class BLEupdater:
 
         # setup sensors of configured devices on startup when device model is available in registry
         if self.config[CONF_DEVICES]:
-            dev_registry = hass.helpers.device_registry.async_get(hass)
-            ent_registry = hass.helpers.entity_registry.async_get(hass)
+            dev_registry = device_registry.async_get(hass)
+            ent_registry = entity_registry.async_get(hass)
             for device in self.config[CONF_DEVICES]:
                 # get device_model and firmware from device registry to setup sensor
                 key = dict_get_or(device)
@@ -158,7 +159,7 @@ class BLEupdater:
                     firmware = RENAMED_FIRMWARE_DICT.get(firmware, firmware)
                     manufacturer = RENAMED_MANUFACTURER_DICT.get(manufacturer, manufacturer)
                     # get all entities for this device
-                    entity_list = hass.helpers.entity_registry.async_entries_for_device(
+                    entity_list = entity_registry.async_entries_for_device(
                         registry=ent_registry, device_id=device_id, include_disabled_entities=False
                     )
                     # find the measurement key for each entity

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest-homeassistant-custom-component==0.13.109
+pytest-homeassistant-custom-component==0.13.119
 
 # BLE montitor requirements
 pycryptodomex==3.19.1


### PR DESCRIPTION
Remove references to hass.helpers. Fix #1350 

See also https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers