### PR TITLE
Fixed missing battery HolyIot

### DIFF
--- a/custom_components/ble_monitor/ble_parser/holyiot.py
+++ b/custom_components/ble_monitor/ble_parser/holyiot.py
@@ -54,7 +54,7 @@ def parse_holyiot(self, data: str, mac: bytes):
             if data[15] == 1:
                 meas_value = "toggle"
             else:
-                return None
+                meas_value = "no press"
         else:
             return None
         result.update(


### PR DESCRIPTION
Previously, when meas_type=6 was received (indicating a battery status update), the code **returned None** early interpreting it as no button press **without updating the battery level**.

This change ensures that the battery level is properly updated even when meas_type=6 is present, while still correctly returning `no press` for button status.