### PR TITLE
Chef iQ CQ60: mask not-measured probe sentinels as None

### DIFF
--- a/custom_components/ble_monitor/ble_parser/chefiq.py
+++ b/custom_components/ble_monitor/ble_parser/chefiq.py
@@ -7,6 +7,22 @@ from .helpers import to_mac, to_unformatted_mac
 _LOGGER = logging.getLogger(__name__)
 
 
+# CQ60 firmware emits these sentinel values when a probe ring has nothing
+# to read (probe partially inserted, broken probe wire, ring not in
+# contact with food). They decode as ~3,276 °C if treated as a real value,
+# which trips HA's temperature device-class limits and produces nonsense
+# graphs / alerts. Mask them to ``None`` so the entity reads as
+# ``unavailable`` instead.
+TEMP_SENTINEL_MIN = 0x7FF0
+
+
+def _decode_temp(raw: int) -> float | None:
+    """Decode a little-endian uint16 temperature in tenths of °C."""
+    if raw >= TEMP_SENTINEL_MIN:
+        return None
+    return round(raw / 10, 1)
+
+
 def parse_chefiq(self, data: str, mac: bytes):
     """Parse Chef iQ advertisement."""
     msg_length = len(data)
@@ -21,12 +37,16 @@ def parse_chefiq(self, data: str, mac: bytes):
         log_cnt = "no packet id"
         result = {
             "battery": batt,
-            "meat temperature": temp_meat / 10,
-            "temperature probe tip": temp_tip / 10,
-            "temperature probe 1": temp_probe_1 / 10,
-            "temperature probe 2": temp_probe_2 / 10,
-            "temperature probe 3": temp_probe_3,
-            "ambient temperature": temp_ambient / 10,
+            "meat temperature": _decode_temp(temp_meat),
+            "temperature probe tip": _decode_temp(temp_tip),
+            "temperature probe 1": _decode_temp(temp_probe_1),
+            "temperature probe 2": _decode_temp(temp_probe_2),
+            # Probe 3 is an 8-bit °C value (no /10 scaling).
+            # 0xFE / 0xFF are the disconnected sentinels.
+            "temperature probe 3": (
+                float(temp_probe_3) if temp_probe_3 < 0xFE else None
+            ),
+            "ambient temperature": _decode_temp(temp_ambient),
         }
     else:
         if self.report_unknown == "Chef iQ":

--- a/custom_components/ble_monitor/test/test_chefiq.py
+++ b/custom_components/ble_monitor/test/test_chefiq.py
@@ -26,3 +26,30 @@ class TestChefiQ:
         assert sensor_msg["ambient temperature"] == 19.2
         assert sensor_msg["battery"] == 99
         assert sensor_msg["rssi"] == -52
+
+    def test_chefiq_cq60_sentinels(self):
+        """CQ60 emits 0x7FFB / 0xFE on probe rings that are not in contact
+        with anything. The parser should mask these as ``None`` so that the
+        downstream Home Assistant entities become *unavailable* instead of
+        reporting bogus 3,276 °C values that trip the temperature
+        device-class limits.
+        """
+        # Same packet header as the working test, but every ring temperature
+        # is the not-measured sentinel:
+        #   meat / tip / probe 1 / probe 2 / ambient = 0xFB7F (LE 0x7FFB)
+        #   probe 3 = 0xFE
+        data_string = "043E250201000073332e3638d91902010615ffcd05014063FEFB7FFB7FFB7FFB7FFB7FFB7F8d11CC"
+        data = bytes(bytearray.fromhex(data_string))
+        ble_parser = BleParser()
+        sensor_msg, _ = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["firmware"] == "Chef iQ"
+        assert sensor_msg["type"] == "CQ60"
+        assert sensor_msg["meat temperature"] is None
+        assert sensor_msg["temperature probe tip"] is None
+        assert sensor_msg["temperature probe 1"] is None
+        assert sensor_msg["temperature probe 2"] is None
+        assert sensor_msg["temperature probe 3"] is None
+        assert sensor_msg["ambient temperature"] is None
+        # Battery and identity fields still populate normally
+        assert sensor_msg["battery"] == 99


### PR DESCRIPTION
### Summary

When a Chef iQ CQ60 ring sensor has nothing touching it (probe only partially inserted, exposed to ambient air, or a broken internal wire) the firmware emits a "not-measured" sentinel rather than a real reading:

| Field | Type | Sentinel |
|---|---|---|
| meat / tip / probe 1 / probe 2 / ambient | `H` (uint16, °C × 10) | `0x7FFB` (and any value `>= 0x7FF0`) |
| probe 3 | `B` (uint8, °C) | `0xFE` / `0xFF` |

The current parser divides those through unchanged, which surfaces in Home Assistant as **`3276.3 °C`** on the affected entities. That:

* trips the `temperature` device-class sanity limits and pollutes recorder/statistics graphs,
* fires any user automations with a `numeric_state: above: 60` trigger the moment the device wakes,
* makes a "doneness" template entity flip into "well done" before any food is even on the probe.

I observed this on a real CQ60 (manufacturer ID `0x05CD`, MAC `D9:38:36:2E:33:73`) — every wake cycle where only the meat probe was inserted produced `meat = 20.1`, `tip = 20.1`, **`probe_1 = probe_2 = ambient = 3276.3`**.

### Change

Add a tiny `_decode_temp(raw)` helper plus a `TEMP_SENTINEL_MIN = 0x7FF0` constant, and route every `H`-encoded ring temperature through it. The 8-bit `probe_3` is masked separately (`< 0xFE`). Any sentinel becomes `None`, so the resulting HA entity reports as `unavailable` instead of an absurd value.

Battery scaling is **deliberately unchanged** in this PR — the existing test asserts `battery == 99` from a raw `0x63` byte, and I haven't been able to confirm from public docs whether the firmware reports a 0–100 percentage or a raw 0–255 byte (my device emits `0xCC` / 204 when freshly charged, which would suggest the latter). Happy to follow up in a separate PR with a scaling change once that's nailed down — I didn't want to entangle it with the (clearer) sentinel correctness fix.

### Tests

* The existing `test_chefiq_cq60` is unchanged and still passes — the sample packet has no sentinel values.
* A new `test_chefiq_cq60_sentinels` case feeds an otherwise-identical packet with every ring temperature set to its sentinel and asserts that all six temperature fields decode to `None` while battery / MAC / type still populate normally.

### Risk

Zero behaviour change for any payload that doesn't contain a sentinel. The masking only affects values that the receiving HA `temperature` sensor would have rejected (or graphed as a 3,000 °C spike) anyway.
