### PR TITLE
fix: Deprecated alias ScannerEntity was used from ble_monitor

### DIFF
--- a/custom_components/ble_monitor/device_tracker.py
+++ b/custom_components/ble_monitor/device_tracker.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from homeassistant.components.device_tracker import SourceType, ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.const import (CONF_DEVICES, CONF_MAC, CONF_NAME,
                                  CONF_UNIQUE_ID, MATCH_ALL, STATE_HOME,
                                  STATE_NOT_HOME)

--- a/custom_components/ble_monitor/device_tracker.py
+++ b/custom_components/ble_monitor/device_tracker.py
@@ -3,8 +3,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import SourceType, ScannerEntity
 from homeassistant.const import (CONF_DEVICES, CONF_MAC, CONF_NAME,
                                  CONF_UNIQUE_ID, MATCH_ALL, STATE_HOME,
                                  STATE_NOT_HOME)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Passive BLE monitor integration",
-  "homeassistant": "2024.11.0"
+  "homeassistant": "2026.6.0"
 }


### PR DESCRIPTION
Fix https://github.com/custom-components/ble_monitor/issues/1544 and bumps the minimum recommended version to one that should definitely always have this API.

https://developers.home-assistant.io/blog/2026/06/15/device-tracker-changes/ I guess would be the docs for the change, but annoyingly, they don't mention this specific deprecation.

Error seems gone on local instance now

