### PR TITLE
Bump pytest-homeassistant-custom-component version

### DIFF
--- a/.github/workflows/test_commit.yml
+++ b/.github/workflows/test_commit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v7"
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt
       - name: Run pytest

--- a/custom_components/ble_monitor/test/conftest.py
+++ b/custom_components/ble_monitor/test/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration for BLE monitor tests."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_event_loop_debug():
+    """Override the async autouse fixture from pytest-homeassistant-custom-component.
+
+    All BLE monitor tests are synchronous and do not need an event loop.
+    This sync override prevents pytest 9 from raising an error when async
+    fixtures are requested by sync tests.
+    """

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-pytest-homeassistant-custom-component==0.13.193
+pytest-homeassistant-custom-component==0.13.354
 
 # BLE monitor requirements
 pycryptodomex==3.23.0


### PR DESCRIPTION
Bump pytest-homeassistant-custom-component to 0.13.354. Required for #1569 
Bump python to 3.14