### PR TITLE
Change device class from HUMIDITY to MOISTURE

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -851,7 +851,7 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         name="ble moisture",
         unique_id="m_",
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.HUMIDITY,
+        device_class=SensorDeviceClass.MOISTURE,
         suggested_display_precision=1,
         state_class=SensorStateClass.MEASUREMENT,
     ),


### PR DESCRIPTION
Change device class from HUMIDITY to MOISTURE for moisture sensors

Fix #1567 