### PR TITLE
Handle unknown Grundfos pump modes

### DIFF
--- a/custom_components/ble_monitor/ble_parser/grundfos.py
+++ b/custom_components/ble_monitor/ble_parser/grundfos.py
@@ -30,7 +30,7 @@ def parse_grundfos(self, data: str, mac: bytes):
     (packet, bat_status, pump_id, flow, press, pump_mode, temp) = unpack(
         "<BBHHhxBB", xvalue
     )
-    pump_mode = PUMP_MODE_DICT[pump_mode]
+    pump_mode = PUMP_MODE_DICT.get(pump_mode, f"Unknown ({pump_mode})")
 
     result = {
         "packet": packet,

--- a/custom_components/ble_monitor/test/test_grundfos.py
+++ b/custom_components/ble_monitor/test/test_grundfos.py
@@ -24,3 +24,13 @@ class TestGrundfos:
         assert sensor_msg["pump id"] == 38917
         assert sensor_msg["battery status"] == 3
         assert sensor_msg["rssi"] == -64
+
+    def test_grundfos_MI401_unknown_pump_mode(self):
+        """Test Grundfos parser does not crash on an undocumented pump mode byte."""
+        data_string = "043E2A020103009565F1164DAC1E06084D4934303116FF14F230017A03059884103E0F19FF0D0114FFFFFFFFC0"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["pump mode"] == "Unknown (255)"


### PR DESCRIPTION
## Summary

Handle unknown Grundfos MI401 pump mode values without crashing the BLE parser.

## Problem

The Grundfos parser used a direct lookup in `PUMP_MODE_DICT`.

If a device reports a pump mode that is not currently known by the integration, the lookup raises `KeyError`. Since the value comes directly from the BLE advertisement, this can also happen with malformed packets or future firmware introducing a new mode.

## Fix

Use a safe dictionary lookup and report unknown values as:

`Unknown (<value>)`

Known pump modes remain unchanged.

A regression test covers an advertisement containing pump mode `255`.