### PR TITLE
Avoid mutating shared restore attribute lists

### DIFF
--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -336,8 +336,7 @@ class BaseBinarySensor(RestoreEntity, BinarySensorEntity):
         elif old_state.state == STATE_OFF:
             self._state = False
 
-        restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
+        restore_attr = RESTORE_ATTRIBUTES + ['mac_address' if self.is_beacon else 'uuid']
 
         for attr in restore_attr:
             if attr in old_state.attributes:

--- a/custom_components/ble_monitor/device_tracker.py
+++ b/custom_components/ble_monitor/device_tracker.py
@@ -195,8 +195,7 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
                 old_state.attributes["last_seen"]
             )
 
-        restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
+        restore_attr = RESTORE_ATTRIBUTES + ['mac_address' if self.is_beacon else 'uuid']
 
         for attr in restore_attr:
             if attr in old_state.attributes:
@@ -344,8 +343,7 @@ class BleScannerEntity(ScannerEntity, RestoreEntity):
                 return
         self._last_seen = now
         self._extra_state_attributes["last_seen"] = self._last_seen
-        restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
+        restore_attr = RESTORE_ATTRIBUTES + ['mac_address' if self.is_beacon else 'uuid']
 
         for attr in restore_attr:
             key = CONF_MAC if attr == 'mac_address' else attr

--- a/custom_components/ble_monitor/sensor.py
+++ b/custom_components/ble_monitor/sensor.py
@@ -541,8 +541,7 @@ class BaseSensor(RestoreSensor, SensorEntity):
 
         # Restore the old attributes
         last_state = await self.async_get_last_state()
-        restore_attr = RESTORE_ATTRIBUTES
-        restore_attr.append('mac_address' if self.is_beacon else 'uuid')
+        restore_attr = RESTORE_ATTRIBUTES + ['mac_address' if self.is_beacon else 'uuid']
 
         for attr in restore_attr:
             if attr in last_state.attributes:


### PR DESCRIPTION
## Summary

Avoid mutating the shared `RESTORE_ATTRIBUTES` lists when restoring entity state.

## Problem

Several restore paths assigned `RESTORE_ATTRIBUTES` directly to a local variable and then appended another attribute to it.

Because lists are mutable, this modified the shared module-level list in place.

The most significant occurrence was in `device_tracker.data_update()`, where the mutation could happen repeatedly during normal BLE updates and continuously add duplicate entries for the lifetime of Home Assistant.

The same pattern was also present in the one time restore paths for device tracker, sensor, and binary sensor entities.

## Fix

Create a new list containing the base restore attributes plus the entity-specific `mac_address` or `uuid` attribute instead of appending to the shared list.

Restore behavior and attribute ordering remain unchanged, while `RESTORE_ATTRIBUTES` itself is no longer modified.