### PR TITLE
Guard truncated Xiaomi toothbrush payloads

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -690,7 +690,8 @@ def obj2000(xobj):
 def obj3003(xobj):
     """Brushing"""
     result = {}
-    print("brush %s", xobj.hex())
+    if len(xobj) < 5:
+        return result
     start_obj = xobj[0]
     if start_obj == 0:
         # Start of brushing

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,7 +2,7 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import obj4851, obj4852
+from ble_monitor.ble_parser.xiaomi import obj3003, obj4851, obj4852
 
 
 class TestXiaomi:
@@ -25,6 +25,11 @@ class TestXiaomi:
         """Test obj4852 parser with malformed payload lengths."""
         assert obj4852(bytes.fromhex("0a0000")) == {}
         assert obj4852(bytes.fromhex("0a00000001")) == {}
+
+    def test_obj3003_truncated_payload(self):
+        """Test obj3003 parser does not crash on a truncated brushing payload."""
+        assert obj3003(bytes.fromhex("00")) == {}
+        assert obj3003(bytes.fromhex("0102030405")[:4]) == {}
 
     def test_Xiaomi_LYWSDCGQ(self):
         """Test Xiaomi parser for LYWSDCGQ."""


### PR DESCRIPTION
## Summary

Prevent malformed Xiaomi toothbrush MiBeacon objects from raising an exception during parsing.

## Problem

`obj3003()` parses brushing start/end events containing a one-byte event marker followed by a four-byte timestamp.

The object payload length comes from the BLE advertisement, but the parser attempted to unpack the timestamp without first verifying that the payload contained enough bytes.

A truncated object with a start or end marker could therefore raise `struct.error` and propagate out of the parser.

The function also contained an unconditional leftover `print()` statement that wrote brushing payloads to stdout.

## Fix

Reject `obj3003` payloads shorter than the five bytes required for the event marker and timestamp.

Valid five byte and six byte brushing payloads remain unchanged, including the optional brushing score.

The stray stdout debug print was also removed.

A regression test covers truncated `obj3003` payloads.