### PR TITLE
Guard invalid Xiaomi motion time payloads

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -853,6 +853,9 @@ def obj484f(xobj):
 
 def obj4850(xobj):
     """Time in minutes with motion (not used, we use 484e)"""
+    if len(xobj) != 1:
+        return {}
+
     (motion_time,) = struct.unpack("<B", xobj)
     # minutes with motion (not used, we use motion timer in obj484e)
     return {"motion time": motion_time}

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,11 +2,20 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import obj4851, obj4852
+from ble_monitor.ble_parser.xiaomi import obj4850, obj4851, obj4852
 
 
 class TestXiaomi:
     """Tests for the Xiaomi parser"""
+
+    def test_obj4850_valid_motion_time(self):
+        """Test obj4850 parser with a valid 1-byte payload."""
+        assert obj4850(bytes.fromhex("05")) == {"motion time": 5}
+
+    def test_obj4850_invalid_motion_time_length(self):
+        """Test obj4850 parser with malformed payload lengths."""
+        assert obj4850(bytes.fromhex("")) == {}
+        assert obj4850(bytes.fromhex("0500")) == {}
 
     def test_obj4851_valid_duration(self):
         """Test obj4851 parser with a valid 4-byte payload."""


### PR DESCRIPTION
## Summary

Prevent malformed Xiaomi MiBeacon motion-time objects from raising an exception during parsing.

## Problem

`obj4850()` parses a one byte motiontime value using `struct.unpack("<B", xobj)`.

The payload length originates from the BLE advertisement and was not validated before unpacking. Payloads with an unexpected length could therefore raise `struct.error` and propagate out of the parser.

## Fix

Require `obj4850` payloads to contain exactly one byte before unpacking them.

Valid one byte payloads remain unchanged, while malformed payloads now return an empty result instead of raising an exception.

Regression tests cover both valid and invalid payload lengths.