### PR TITLE
Handle invalid BTHome UTF-8 strings

### DIFF
--- a/custom_components/ble_monitor/ble_parser/bthome.py
+++ b/custom_components/ble_monitor/ble_parser/bthome.py
@@ -43,9 +43,13 @@ def parse_float(data_obj: bytes, factor: float = 1.0):
     return round(val * factor, decimal_places)
 
 
-def parse_string(data_obj: bytes) -> str:
+def parse_string(data_obj: bytes) -> str | None:
     """Convert bytes to string."""
-    return data_obj.decode("UTF-8")
+    try:
+        return data_obj.decode("UTF-8")
+    except UnicodeDecodeError:
+        _LOGGER.debug("Invalid UTF-8 string in BTHome BLE payload: %s", data_obj.hex())
+        return None
 
 
 def parse_timestamp(data_obj: bytes) -> datetime:

--- a/custom_components/ble_monitor/test/test_bthome_v2.py
+++ b/custom_components/ble_monitor/test/test_bthome_v2.py
@@ -1190,6 +1190,21 @@ class TestBTHome:
         assert sensor_msg["text"] == "Hello World!"
         assert sensor_msg["rssi"] == -52
 
+    def test_bthome_v2_invalid_utf8_text(self):
+        """Test BTHome parser does not crash on a malformed (non-UTF-8) text measurement."""
+        # Same as test_bthome_v2_text, but the 12-byte "Hello World!" payload is
+        # replaced with 12 invalid UTF-8 bytes (0x80 is never a valid lead byte).
+        data_string = "043E2202010000A5808FE64854160201061216D2FC40530C808080808080808080808080CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        # No exception raised, and no bogus "text" measurement is produced: this
+        # advertisement only contains the malformed text object, so the result is None.
+        assert sensor_msg is None
+
     def test_bthome_v2_double_temperature(self):
         """Test BTHome parser for double temperature measurement, which isn't supported (yet)"""
         data_string = "043E1A02010000A5808FE648540E0201060A16D2FC40450101450301CC"


### PR DESCRIPTION
## Summary

Prevent malformed BTHome text measurements from raising `UnicodeDecodeError`.

## Problem

`parse_string()` decoded raw BLE payload bytes directly as UTF-8 without handling invalid byte sequences.

Because BTHome measurement data comes directly from BLE advertisements, malformed or unexpected string payloads could raise `UnicodeDecodeError` and propagate out of the parser.

## Fix

Catch invalid UTF-8 decoding errors and return `None`, which is the existing sentinel used by the BTHome measurement pipeline for values that cannot be parsed.

Valid UTF-8 strings remain unchanged.

Malformed string payloads are logged at debug level to avoid repeated invalid advertisements flooding Home Assistant logs.

A regression test covers invalid UTF-8 text payloads.