### PR TITLE
Guard empty Xiaomi button payloads

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -1010,6 +1010,8 @@ def obj4e01(xobj):
 def obj4e0c(xobj, device_type):
     """Click"""
     if device_type == "XMWXKG01YL":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {
@@ -1028,6 +1030,8 @@ def obj4e0c(xobj, device_type):
                 "button switch": "single press",
             }
     elif device_type == "K9BB-1BTN":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {
@@ -1050,6 +1054,8 @@ def obj4e0c(xobj, device_type):
             "button switch": "single press",
         }
     elif device_type == "PTX-F1-Display":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {
@@ -1081,6 +1087,8 @@ def obj4e0c(xobj, device_type):
 def obj4e0d(xobj, device_type):
     """Double Click"""
     if device_type == "XMWXKG01YL":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {
@@ -1104,6 +1112,8 @@ def obj4e0d(xobj, device_type):
             "button switch": "double press",
         }
     elif device_type == "PTX-F1-Display":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {
@@ -1135,6 +1145,8 @@ def obj4e0d(xobj, device_type):
 def obj4e0e(xobj, device_type):
     """Long Press"""
     if device_type == "XMWXKG01YL":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {
@@ -1158,6 +1170,8 @@ def obj4e0e(xobj, device_type):
             "button switch": "long press",
         }
     elif device_type == "PTX-F1-Display":
+        if not xobj:
+            return {}
         click = xobj[0]
         if click == 1:
             result = {

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,11 +2,39 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import obj4851, obj4852
+from ble_monitor.ble_parser.xiaomi import obj4851, obj4852, obj4e0c, obj4e0d, obj4e0e
 
 
 class TestXiaomi:
     """Tests for the Xiaomi parser"""
+
+    def test_obj4e0c_empty_payload(self):
+        """obj4e0c: empty payload is {} for every vulnerable device_type; XMWXKG01LM is unaffected."""
+        assert obj4e0c(b"", "XMWXKG01YL") == {}
+        assert obj4e0c(b"", "K9BB-1BTN") == {}
+        assert obj4e0c(b"", "PTX-F1-Display") == {}
+        assert obj4e0c(b"", "XMWXKG01LM") == {
+            "one btn switch": "toggle",
+            "button switch": "single press",
+        }
+
+    def test_obj4e0d_empty_payload(self):
+        """obj4e0d: empty payload is {} for every vulnerable device_type; XMWXKG01LM is unaffected."""
+        assert obj4e0d(b"", "XMWXKG01YL") == {}
+        assert obj4e0d(b"", "PTX-F1-Display") == {}
+        assert obj4e0d(b"", "XMWXKG01LM") == {
+            "one btn switch": "toggle",
+            "button switch": "double press",
+        }
+
+    def test_obj4e0e_empty_payload(self):
+        """obj4e0e: empty payload is {} for every vulnerable device_type; XMWXKG01LM is unaffected."""
+        assert obj4e0e(b"", "XMWXKG01YL") == {}
+        assert obj4e0e(b"", "PTX-F1-Display") == {}
+        assert obj4e0e(b"", "XMWXKG01LM") == {
+            "one btn switch": "toggle",
+            "button switch": "long press",
+        }
 
     def test_obj4851_valid_duration(self):
         """Test obj4851 parser with a valid 4-byte payload."""

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,9 +2,8 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import (
-  obj3003, obj4850, obj4851, obj4852, obj4e0c, obj4e0d, obj4e0e
-)
+from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj3003,
+                                           obj4850, obj4851, obj4852)
 
 
 class TestXiaomi:


### PR DESCRIPTION
## Summary

Prevent empty Xiaomi MiBeacon button event payloads from raising `IndexError`.

## Problem

The Xiaomi parsers for single click, double click, and long press events access the first payload byte for several device types.

These object types can legitimately reach the parser with an empty payload, so malformed advertisements for affected devices could trigger `xobj[0]` on an empty byte string and raise `IndexError`.

Some Xiaomi devices intentionally use an empty payload to signal a button event, so a blanket empty-payload guard would incorrectly break valid behavior.