### PR TITLE
Handle unknown PTX button values

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -1073,7 +1073,7 @@ def obj4e0c(xobj, device_type):
                 "button switch": "single press",
             }
         else:
-            result = None
+            result = {}
     else:
         result = {}
     return result
@@ -1127,7 +1127,7 @@ def obj4e0d(xobj, device_type):
                 "button switch": "double press",
             }
         else:
-            result = None
+            result = {}
     else:
         result = {}
     return result
@@ -1181,7 +1181,7 @@ def obj4e0e(xobj, device_type):
                 "button switch": "long press",
             }
         else:
-            result = None
+            result = {}
     else:
         result = {}
     return result

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,11 +2,41 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import obj3003, obj4851, obj4852
+from ble_monitor.ble_parser.xiaomi import obj3003, obj4851, obj4852, obj4e0c, obj4e0d, obj4e0e
 
 
 class TestXiaomi:
     """Tests for the Xiaomi parser"""
+
+    def test_obj4e0c_ptx_f1_display_click(self):
+        """obj4e0c PTX-F1-Display: unrecognized click is {}; recognized clicks are unchanged."""
+        assert obj4e0c(bytes([0]), "PTX-F1-Display") == {}
+        assert obj4e0c(bytes([1]), "PTX-F1-Display") == {
+            "four btn switch 1": "toggle", "button switch": "single press"
+        }
+        assert obj4e0c(bytes([4]), "PTX-F1-Display") == {
+            "four btn switch 4": "toggle", "button switch": "single press"
+        }
+
+    def test_obj4e0d_ptx_f1_display_click(self):
+        """obj4e0d PTX-F1-Display: unrecognized click is {}; recognized clicks are unchanged."""
+        assert obj4e0d(bytes([0]), "PTX-F1-Display") == {}
+        assert obj4e0d(bytes([1]), "PTX-F1-Display") == {
+            "four btn switch 1": "toggle", "button switch": "double press"
+        }
+        assert obj4e0d(bytes([4]), "PTX-F1-Display") == {
+            "four btn switch 4": "toggle", "button switch": "double press"
+        }
+
+    def test_obj4e0e_ptx_f1_display_click(self):
+        """obj4e0e PTX-F1-Display: unrecognized click is {}; recognized clicks are unchanged."""
+        assert obj4e0e(bytes([0]), "PTX-F1-Display") == {}
+        assert obj4e0e(bytes([1]), "PTX-F1-Display") == {
+            "four btn switch 1": "toggle", "button switch": "long press"
+        }
+        assert obj4e0e(bytes([4]), "PTX-F1-Display") == {
+            "four btn switch 4": "toggle", "button switch": "long press"
+        }
 
     def test_obj4851_valid_duration(self):
         """Test obj4851 parser with a valid 4-byte payload."""


### PR DESCRIPTION
## Summary

Prevent unexpected PTX-F1-Display button values from causing a Xiaomi parser exception.

## Problem

The PTX-F1-Display branches in `obj4e0c()`, `obj4e0d()`, and `obj4e0e()` returned `None` when the click byte was not one of the recognized values.

The Xiaomi parser passes the returned value directly to `dict.update()`, so an unknown click value caused:

`TypeError: 'NoneType' object is not iterable`

The click byte originates from the BLE advertisement and can contain unexpected values.

## Fix

Return an empty result for unrecognized PTX-F1-Display click values instead of `None`.

Recognized button events remain unchanged.

Regression tests cover unknown and recognized PTX-F1-Display button values.