### PR TITLE
Handle unknown Xiaomi button values

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -1033,6 +1033,8 @@ def obj4e0c(xobj, device_type):
                 "two btn switch right": "toggle",
                 "button switch": "single press",
             }
+        else:
+            result = {}
     elif device_type == "K9BB-1BTN":
         if not xobj:
             return {}
@@ -1052,6 +1054,8 @@ def obj4e0c(xobj, device_type):
                 "one btn switch": "toggle",
                 "button switch": "double press",
             }
+        else:
+            result = {}
     elif device_type == "XMWXKG01LM":
         result = {
             "one btn switch": "toggle",
@@ -1110,6 +1114,8 @@ def obj4e0d(xobj, device_type):
                 "two btn switch right": "toggle",
                 "button switch": "double press",
             }
+        else:
+            result = {}
     elif device_type == "XMWXKG01LM":
         result = {
             "one btn switch": "toggle",
@@ -1168,6 +1174,8 @@ def obj4e0e(xobj, device_type):
                 "two btn switch right": "toggle",
                 "button switch": "long press",
             }
+        else:
+            result = {}
     elif device_type == "XMWXKG01LM":
         result = {
             "one btn switch": "toggle",

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -36,6 +36,32 @@ class TestXiaomi:
             "one btn switch": "toggle",
             "button switch": "long press",
         }
+
+    def test_obj4e0c_unrecognized_click(self):
+        """obj4e0c: unrecognized click is {} instead of UnboundLocalError; known clicks unchanged."""
+        assert obj4e0c(bytes([0]), "XMWXKG01YL") == {}
+        assert obj4e0c(bytes([0]), "K9BB-1BTN") == {}
+        assert obj4e0c(bytes([1]), "XMWXKG01YL") == {
+            "two btn switch left": "toggle", "button switch": "single press"
+        }
+        assert obj4e0c(bytes([1]), "K9BB-1BTN") == {
+            "one btn switch": "toggle", "button switch": "single press"
+        }
+
+    def test_obj4e0d_unrecognized_click(self):
+        """obj4e0d: unrecognized click is {} instead of UnboundLocalError; known click unchanged."""
+        assert obj4e0d(bytes([0]), "XMWXKG01YL") == {}
+        assert obj4e0d(bytes([1]), "XMWXKG01YL") == {
+            "two btn switch left": "toggle", "button switch": "double press"
+        }
+
+    def test_obj4e0e_unrecognized_click(self):
+        """obj4e0e: unrecognized click is {} instead of UnboundLocalError; known click unchanged."""
+        assert obj4e0e(bytes([0]), "XMWXKG01YL") == {}
+        assert obj4e0e(bytes([1]), "XMWXKG01YL") == {
+            "two btn switch left": "toggle", "button switch": "long press"
+        }
+
     def test_obj4850_valid_motion_time(self):
         """Test obj4850 parser with a valid 1-byte payload."""
         assert obj4850(bytes.fromhex("05")) == {"motion time": 5}


### PR DESCRIPTION
## Summary

Prevent unexpected Xiaomi button values from causing `UnboundLocalError` during MiBeacon parsing.

## Problem

Several button event branches only assigned `result` for known click values.

For an unexpected value from the BLE advertisement, execution could reach `return result` without `result` ever being assigned, raising `UnboundLocalError`.

The affected branches are:

- `XMWXKG01YL` in single click, double click, and long press parsing
- `K9BB-1BTN` in single-click parsing

## Fix

Return an empty result for unrecognized click values.

Existing behavior for recognized button events remains unchanged, while unexpected advertisement values are safely ignored instead of raising an exception.

Regression tests cover both unknown and recognized click values.