### PR TITLE
Handle invalid Xiaomi button objects

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -513,11 +513,11 @@ def obj1001(xobj, device_type):
             if three_btn_switch_right:
                 result["three btn switch right"] = three_btn_switch_right
         else:
-            return None
+            return {}
         return result
 
     else:
-        return None
+        return {}
 
 
 def obj1004(xobj):

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,8 +2,8 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj3003,
-                                           obj4850, obj4851, obj4852)
+from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj1001,
+                                           obj3003, obj4850, obj4851, obj4852)
 
 
 class TestXiaomi:
@@ -67,6 +67,20 @@ class TestXiaomi:
         """Test obj3003 parser does not crash on a truncated brushing payload."""
         assert obj3003(bytes.fromhex("00")) == {}
         assert obj3003(bytes.fromhex("0102030405")[:4]) == {}
+
+    def test_obj1001_invalid_input(self):
+        """obj1001: invalid length and unrecognized device_type return {} instead of None."""
+        assert obj1001(bytes.fromhex("0001"), "YLYK01YL") == {}
+        assert obj1001(bytes.fromhex("000102030405"), "YLYK01YL") == {}
+        assert obj1001(bytes.fromhex("000000"), "SOME-UNKNOWN-DEVICE") == {}
+
+    def test_obj1001_valid_payload(self):
+        """obj1001: a known valid payload still returns the existing result."""
+        assert obj1001(bytes.fromhex("000100"), "YLYK01YL") == {
+            "remote": "on",
+            "button": "single press",
+            "remote single press": 1,
+        }
 
     def test_Xiaomi_LYWSDCGQ(self):
         """Test Xiaomi parser for LYWSDCGQ."""


### PR DESCRIPTION
## Summary

Prevent invalid Xiaomi MiBeacon button objects from causing a parser exception.

## Problem

`obj1001()` returned `None` for invalid payload lengths and for unrecognized device types.

The Xiaomi parser passes object-parser results directly to `dict.update()`, so these cases could result in:

`TypeError: 'NoneType' object is not iterable`

Both the object length and device identifier originate from the BLE advertisement and can contain unexpected values.

## Fix

Return an empty result for invalid payload lengths and unsupported device types instead of `None`.

Valid button event parsing remains unchanged.

Regression tests cover invalid input and a representative valid button event.