### PR TITLE
Handle unknown Xiaomi sleep states

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -775,7 +775,7 @@ def obj4810(xobj):
     elif sleep_state == 2:
         return {"button switch": "double press"}
     else:
-        return None
+        return {}
 
 
 def obj4811(xobj):
@@ -1251,7 +1251,7 @@ def obj5010(xobj):
     elif sleep_state == 2:
         return {"button": "double press"}
     else:
-        return None
+        return {}
 
 
 def obj5011(xobj):

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -3,7 +3,8 @@ import datetime
 
 from ble_monitor.ble_parser import BleParser
 from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj1001,
-                                           obj3003, obj4850, obj4851, obj4852)
+                                           obj3003, obj4810, obj4850, obj4851,
+                                           obj4852, obj5010)
 
 
 class TestXiaomi:
@@ -136,6 +137,18 @@ class TestXiaomi:
             "button": "single press",
             "remote single press": 1,
         }
+
+    def test_obj4810_unrecognized_sleep_state(self):
+        """obj4810: unrecognized sleep_state is {}; recognized values are unchanged."""
+        assert obj4810(bytes.fromhex("03")) == {}
+        assert obj4810(bytes.fromhex("ff")) == {}
+        assert obj4810(bytes.fromhex("01")) == {"sleeping": 1}
+
+    def test_obj5010_unrecognized_sleep_state(self):
+        """obj5010: unrecognized sleep_state is {}; recognized values are unchanged."""
+        assert obj5010(bytes.fromhex("03")) == {}
+        assert obj5010(bytes.fromhex("ff")) == {}
+        assert obj5010(bytes.fromhex("01")) == {"sleeping": 1}
 
     def test_Xiaomi_LYWSDCGQ(self):
         """Test Xiaomi parser for LYWSDCGQ."""


### PR DESCRIPTION
## Summary

Prevent unexpected Xiaomi MiBeacon sleep-state values from causing a parser exception.

## Problem

`obj4810()` and `obj5010()` returned `None` for unrecognized sleep-state values.

The Xiaomi parser passes object-parser results directly to `dict.update()`, so an unknown value could result in:

`TypeError: 'NoneType' object is not iterable`

The sleep-state byte comes directly from the BLE advertisement and may contain unexpected values.

## Fix

Return an empty result for unrecognized sleep state values instead of `None`.

Recognized sleep states remain unchanged.

Regression tests cover unknown and valid sleepstate values for both parsers.