### PR TITLE
Handle unknown Xiaomi bed occupancy events

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -1218,7 +1218,7 @@ def obj4e16(xobj):
     if event == 1:
         return {"bed occupancy": 1}
     else:
-        return None
+        return {}
 
 
 def obj4e17(xobj):
@@ -1227,7 +1227,7 @@ def obj4e17(xobj):
     if event == 1:
         return {"bed occupancy": 0}
     else:
-        return None
+        return {}
 
 
 def obj4e1c(xobj):
@@ -1379,7 +1379,7 @@ def obj5a16(xobj):
     elif event == 3:
         return {"button": "double press"}
     else:
-        return None
+        return {}
 
 
 def obj6012(xobj):

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -3,7 +3,8 @@ import datetime
 
 from ble_monitor.ble_parser import BleParser
 from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj1001,
-                                           obj3003, obj4850, obj4851, obj4852)
+                                           obj3003, obj4850, obj4851, obj4852,
+                                           obj4e16, obj4e17, obj5a16)
 
 
 class TestXiaomi:
@@ -136,6 +137,21 @@ class TestXiaomi:
             "button": "single press",
             "remote single press": 1,
         }
+
+    def test_obj4e16_unrecognized_event(self):
+        """obj4e16: unrecognized event is {}; recognized event is unchanged."""
+        assert obj4e16(bytes.fromhex("02")) == {}
+        assert obj4e16(bytes.fromhex("01")) == {"bed occupancy": 1}
+
+    def test_obj4e17_unrecognized_event(self):
+        """obj4e17: unrecognized event is {}; recognized event is unchanged."""
+        assert obj4e17(bytes.fromhex("02")) == {}
+        assert obj4e17(bytes.fromhex("01")) == {"bed occupancy": 0}
+
+    def test_obj5a16_unrecognized_event(self):
+        """obj5a16: unrecognized event is {}; recognized event is unchanged."""
+        assert obj5a16(bytes.fromhex("04")) == {}
+        assert obj5a16(bytes.fromhex("03")) == {"button": "double press"}
 
     def test_Xiaomi_LYWSDCGQ(self):
         """Test Xiaomi parser for LYWSDCGQ."""

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,9 +2,9 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj1001,
-                                           obj3003, obj4810, obj4850, obj4851,
-                                           obj4852, obj4e16, obj4e17, obj5a16,
+from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj4e16,
+                                           obj4e17, obj5a16, obj1001, obj3003,
+                                           obj4810, obj4850, obj4851, obj4852,
                                            obj5010)
 
 


### PR DESCRIPTION
## Summary

Prevent unexpected Xiaomi MiBeacon bed-occupancy event values from causing a parser exception.

## Problem

`obj4e16()`, `obj4e17()`, and `obj5a16()` returned `None` for unrecognized event values.

The Xiaomi parser passes object-parser results directly to `dict.update()`, so an unexpected event byte could result in:

`TypeError: 'NoneType' object is not iterable`

The event byte comes directly from the BLE advertisement and may contain unexpected values.

## Fix

Return an empty result for unrecognized event values instead of `None`.

Recognized bed occupancy and button events remain unchanged.

Regression tests cover unknown and valid event values for all three parsers.