### PR TITLE
Handle invalid Xiaomi KS1 button events

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -1301,10 +1301,10 @@ def obj560c(xobj, device_type):
                 "button switch": "single press",
             }
         else:
-            result = None
+            result = {}
         return result
     else:
-        return None
+        return {}
 
 
 def obj560d(xobj, device_type):
@@ -1332,10 +1332,10 @@ def obj560d(xobj, device_type):
                 "button switch": "double press",
             }
         else:
-            result = None
+            result = {}
         return result
     else:
-        return None
+        return {}
 
 
 def obj560e(xobj, device_type):
@@ -1363,10 +1363,10 @@ def obj560e(xobj, device_type):
                 "button switch": "long press",
             }
         else:
-            result = None
+            result = {}
         return result
     else:
-        return None
+        return {}
 
 
 def obj5a16(xobj):

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -3,7 +3,8 @@ import datetime
 
 from ble_monitor.ble_parser import BleParser
 from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj1001,
-                                           obj3003, obj4850, obj4851, obj4852)
+                                           obj3003, obj4850, obj4851, obj4852,
+                                           obj560c, obj560d, obj560e)
 
 
 class TestXiaomi:
@@ -136,6 +137,19 @@ class TestXiaomi:
             "button": "single press",
             "remote single press": 1,
         }
+
+    def test_obj560c_obj560d_obj560e_invalid_input(self):
+        """obj560c/obj560d/obj560e: unknown click and unsupported device_type return {};
+        a recognized click for KS1/KS1BP is unchanged."""
+        for fn, press in ((obj560c, "single press"), (obj560d, "double press"), (obj560e, "long press")):
+            assert fn(bytes.fromhex("00"), "KS1") == {}
+            assert fn(bytes.fromhex("01"), "SOME-UNKNOWN-DEVICE") == {}
+            assert fn(bytes.fromhex("01"), "KS1") == {
+                "four btn switch 1": "toggle", "button switch": press
+            }
+            assert fn(bytes.fromhex("01"), "KS1BP") == {
+                "four btn switch 1": "toggle", "button switch": press
+            }
 
     def test_Xiaomi_LYWSDCGQ(self):
         """Test Xiaomi parser for LYWSDCGQ."""

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -3,9 +3,9 @@ import datetime
 
 from ble_monitor.ble_parser import BleParser
 from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj4e16,
-                                           obj4e17, obj5a16, obj1001, obj3003,
-                                           obj4810, obj4850, obj4851, obj4852,
-                                           obj5010, obj560c, obj560d, obj560e)
+                                           obj4e17, obj5a16, obj560c, obj560d,
+                                           obj560e, obj1001, obj3003, obj4810,
+                                           obj4850, obj4851, obj4852, obj5010)
 
 
 class TestXiaomi:

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -2,9 +2,9 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
-from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj1001,
-                                           obj3003, obj4850, obj4851, obj4852,
-                                           obj560c, obj560d, obj560e)
+from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj560c,
+                                           obj560d, obj560e, obj1001, obj3003,
+                                           obj4850, obj4851, obj4852)
 
 
 class TestXiaomi:


### PR DESCRIPTION
## Summary

Prevent invalid Xiaomi KS1/KS1BP button events from causing parser exceptions.

## Problem

`obj560c()`, `obj560d()`, and `obj560e()` returned `None` for unrecognized click values and unsupported device types.

The Xiaomi parser passes object-parser results directly to `dict.update()`, so these cases could result in:

`TypeError: 'NoneType' object is not iterable`

Both the device identifier and click value originate from the BLE advertisement and may contain unexpected values.

## Fix

Return an empty result for unrecognized click values and unsupported device types instead of `None`.

Recognized KS1/KS1BP single click, double click, and long press events remain unchanged.

Regression tests cover invalid inputs and representative valid button events.