### PR TITLE
Correct Govee H5071 device detection

### DIFF
--- a/custom_components/ble_monitor/ble_parser/govee.py
+++ b/custom_components/ble_monitor/ble_parser/govee.py
@@ -113,7 +113,7 @@ def parse_govee(self, data: str, service_class_uuid16: int, local_name: str, mac
     ):
         if service_class_uuid16 == 0x5052:
             device_type = "H5052"
-        elif service_class_uuid16 == 5071:
+        elif service_class_uuid16 == 0x5071:
             device_type = "H5071"
         else:
             device_type = "H5051"

--- a/custom_components/ble_monitor/test/test_govee_parser.py
+++ b/custom_components/ble_monitor/test/test_govee_parser.py
@@ -22,6 +22,24 @@ class TestGovee:
         assert sensor_msg["battery"] == 99
         assert sensor_msg["rssi"] == -73
 
+    def test_Govee_H5071(self):
+        """Test Govee H5071 parser."""
+        data_string = "043e1d02010400aabb615960e311030250710cff88ec00ba0af90f63020101b7"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["firmware"] == "Govee"
+        assert sensor_msg["type"] == "H5071"
+        assert sensor_msg["mac"] == "E3605961BBAA"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 27.46
+        assert sensor_msg["humidity"] == 40.89
+        assert sensor_msg["battery"] == 99
+        assert sensor_msg["rssi"] == -73
+
     def test_Govee_H5055(self):
         """Test Govee H5055 parser."""
         data_string = "043e270201000005351338c1a41b02010617ff1cea3500644120ffffffffffff203200ffffffff0000c4"


### PR DESCRIPTION
## Summary

Correct the device-type detection for Govee H5071 sensors.

## Problem

The Govee parser compared the service UUID against the decimal literal `5071` instead of the hexadecimal value `0x5071`.

As a result, advertisements from real H5071 devices could never match the intended H5071 branch and were incorrectly identified as H5051.

## Fix

Use the correct hexadecimal service UUID value when detecting H5071 devices.

H5071 advertisements are now identified correctly, while existing H5051 and other Govee model handling remains unchanged.

A regression test covers H5071 detection.