### PR TITLE
Handle malformed Sonoff advertisements

### DIFF
--- a/custom_components/ble_monitor/ble_parser/sonoff.py
+++ b/custom_components/ble_monitor/ble_parser/sonoff.py
@@ -52,7 +52,7 @@ def decrypt_sonoff(encrypted_data: bytes, seed: int) -> bytes:
 
 def parse_sonoff(self, data: bytes, mac: bytes) -> dict[str, Any] | None:
     # Verify MAC address and data length
-    if mac != b"\x66\x55\x44\x33\x22\x11" or len(data) < 10:
+    if mac != b"\x66\x55\x44\x33\x22\x11" or len(data) < 21:
         return None
 
     firmware = "Sonoff"
@@ -99,7 +99,7 @@ def parse_sonoff(self, data: bytes, mac: bytes) -> dict[str, Any] | None:
                 to_mac(mac),
                 data.hex()
             )
-            return None
+        return None
 
     try:
         result = {

--- a/custom_components/ble_monitor/test/test_sonoff.py
+++ b/custom_components/ble_monitor/test/test_sonoff.py
@@ -39,3 +39,25 @@ class TestSonoff:
         assert sensor_msg["six btn switch top left"] == "toggle"
         assert sensor_msg["button switch"] == "single press"
         assert sensor_msg["rssi"] == -82
+
+    def test_sonoff_too_short_returns_cleanly(self):
+        """A Sonoff advertisement shorter than the required payload must not raise."""
+        data_string = "043e2302010301112233445566170201021305ffffee1bc878f64a4690dd5ad9e71f4e4177ba"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg is None
+
+    def test_sonoff_unknown_device_type_returns_cleanly(self):
+        """An unrecognized Sonoff device type byte must not raise."""
+        data_string = "043e2b020103011122334455661f0201021b05ffffee1bc878f64a9990dd5ad9e71f4e4177f011694babb7fe68ba"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg is None


### PR DESCRIPTION
## Summary

Prevent malformed or unsupported Sonoff BLE advertisements from causing parser exceptions.

## Problem

The Sonoff parser had two failure cases:

- Its initial length guard allowed payloads that were still too short for later encrypted-data processing, which could result in `IndexError`.
- An unknown Sonoff device type could leave `device_type` undefined when `report_unknown` was disabled, resulting in `UnboundLocalError`.

## Fix

Require the minimum payload length actually needed by the parser before processing the advertisement.

Also ensure unknown Sonoff device types always return cleanly after the optional diagnostic logging path.

Known Sonoff S-MATE and R5 parsing remains unchanged.

Regression tests cover truncated advertisements and unknown device types.