### PR TITLE
Guard short Michelin advertisements

### DIFF
--- a/custom_components/ble_monitor/ble_parser/michelin.py
+++ b/custom_components/ble_monitor/ble_parser/michelin.py
@@ -10,6 +10,8 @@ _LOGGER = logging.getLogger(__name__)
 def parse_michelin_tms(self, data: bytes, mac: bytes):
     """Parser for Michelin TMS."""
     msg_length = len(data)
+    if msg_length < 6:
+        return None
     device_type = "TMS"
     firmware = "TMS"
     result = {"firmware": firmware}

--- a/custom_components/ble_monitor/test/test_michelin.py
+++ b/custom_components/ble_monitor/test/test_michelin.py
@@ -24,3 +24,14 @@ class TestMichelin:
         assert sensor_msg["steps"] == 1
         assert sensor_msg["text"] == "PVC"
         assert sensor_msg["rssi"] == -68
+
+    def test_parse_michelin_tms_too_short_returns_cleanly(self):
+        """A Michelin TMS advertisement shorter than the required payload must not raise."""
+        data_string = "043e1402010300e07c03a703bc0802010604ff280801bc"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg is None


### PR DESCRIPTION
## Summary

Prevent short Michelin TMS advertisements from raising `IndexError` during parsing.

## Problem

`parse_michelin_tms()` accessed `data[5]` before validating that the manufacturer data contained at least six bytes.

The shared dispatcher does not enforce a sufficient minimum length for Michelin advertisements, so truncated packets could reach the parser and raise an exception.

## Fix

Reject Michelin TMS payloads shorter than six bytes before accessing the frame-type byte.

Valid Michelin advertisements and the existing frame specific validation remain unchanged.

A regression test covers truncated manufacturer data.