### PR TITLE
Guard short BLE parser payloads

### DIFF
--- a/custom_components/ble_monitor/ble_parser/almendo.py
+++ b/custom_components/ble_monitor/ble_parser/almendo.py
@@ -18,10 +18,14 @@ def parse_almendo(self, data: bytes, mac: bytes):
     if adstruct_type == 0xFF:
         comp_id = (data[3] << 8) | data[2]
         if comp_id == 0x06E8:
-            # version, device_type, device_model, hw_revistion,
-            # status_bits, sstatus_code
-            version, _, dmodel, _, _, _ = data[4:10]
-            if version == 1 and dmodel == 0x0A:
+            if len(data) < 10:
+                result = None
+            elif data[4] == 1 and data[6] == 0x0A and len(data) < 20:
+                result = None
+            elif data[4] == 1 and data[6] == 0x0A:
+                # version, device_type, device_model, hw_revistion,
+                # status_bits, sstatus_code
+                version, _, dmodel, _, _, _ = data[4:10]
                 # Almendo bluSensor V1 format (BSP02AIQ)
                 # sensor_state, temp, humi, co2e, tvoc, aiq
                 (_, temp, humi, co2e, tvoc, aqi) = unpack(

--- a/custom_components/ble_monitor/ble_parser/ruuvitag.py
+++ b/custom_components/ble_monitor/ble_parser/ruuvitag.py
@@ -58,8 +58,13 @@ def parse_ruuvitag(self, data: bytes, mac: bytes):
         # version 3 and 5
         comp_id = (data[3] << 8) | data[2]
         if comp_id == 0x0499:
-            version = data[4]
-            if version == 3:
+            if len(data) < 5:
+                result = None
+            elif data[4] == 3 and len(data) < 18:
+                result = None
+            elif data[4] == 5 and len(data) < 22:
+                result = None
+            elif data[4] == 3:
                 # Ruuvitag V3 format
                 (version, humi, temp, frac, press, accx, accy, accz, volt) = struct.unpack(
                     ">BBbBHhhhH", data[4:18]
@@ -94,7 +99,7 @@ def parse_ruuvitag(self, data: bytes, mac: bytes):
                         "data": True,
                     }
                 )
-            elif version == 5:
+            elif data[4] == 5:
                 # Ruuvitag V5 format
                 (version, temp, humi, press, accx, accy, accz, power, move_cnt, packet_id) = struct.unpack(
                     ">BhHHhhhHBH", data[4:22]

--- a/custom_components/ble_monitor/ble_parser/sensirion.py
+++ b/custom_components/ble_monitor/ble_parser/sensirion.py
@@ -28,6 +28,9 @@ def parse_sensirion(self, data: bytes, complete_local_name: str, mac: bytes):
             )
         return None
 
+    if len(data) < 8:
+        return None
+
     # not all of the following values are used yet, but this explains the full protocol
     # bytes 1+2 (length and type) are part of the header
     advertisementLength = data[0]  # redundant

--- a/custom_components/ble_monitor/test/test_almendo.py
+++ b/custom_components/ble_monitor/test/test_almendo.py
@@ -23,3 +23,13 @@ class TestAlmendo:
         assert sensor_msg["aqi"] == 3
         assert sensor_msg["co2"] == 934
         assert sensor_msg["rssi"] == -52
+
+    def test_almendo_too_short_returns_cleanly(self):
+        """An Almendo advertisement shorter than the required payload must not raise."""
+        data_string = "043e21020103010eba64c4f5fc150201060effe806010a0a08011800fb09e511cc"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg is None

--- a/custom_components/ble_monitor/test/test_ruuvitag_parser.py
+++ b/custom_components/ble_monitor/test/test_ruuvitag_parser.py
@@ -91,3 +91,13 @@ class TestRuuviTag:
         assert sensor_msg["motion"] == 0
         assert sensor_msg["motion timer"] == 0
         assert sensor_msg["rssi"] == -68
+
+    def test_ruuvitag_v3_too_short_returns_cleanly(self):
+        """A Ruuvitag V3 advertisement shorter than the required payload must not raise."""
+        data_string = "043e1b02010301f27a52fad4cd0f0201040bff990403291a1ece1efc189e"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg is None

--- a/custom_components/ble_monitor/test/test_sensirion_parser.py
+++ b/custom_components/ble_monitor/test/test_sensirion_parser.py
@@ -38,3 +38,13 @@ class TestSensirion:
         assert sensor_msg["temperature"] == 27.47
         assert sensor_msg["humidity"] == 43.37
         assert sensor_msg["rssi"] == -71
+
+    def test_Sensirion_too_short_returns_cleanly(self):
+        """A Sensirion advertisement shorter than the required payload must not raise."""
+        data_string = "043e2b0d0113000135673cdceaf80100ff7fb00000000000000000001102010606ffd50600086706094d79434f32"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg is None


### PR DESCRIPTION
## Summary

Add missing payload-length validation to several BLE parsers.

## Problem

The Sensirion, Almendo, and RuuviTag parsers could receive truncated manufacturer data that passed the shared dispatcher but was still too short for direct indexing or `struct.unpack()` calls.

Depending on the parser and payload length, this could result in exceptions such as:

- `IndexError`
- `ValueError`
- `struct.error`

## Fix

Add parser specific length validation before accessing fields that require a minimum payload size.

The checks are kept format-specific where necessary, especially for RuuviTag V3 and V5 payloads, so valid shorter formats are not rejected.

Regression tests cover truncated advertisements while preserving existing valid parsing behavior.