### PR TITLE
Migrate deprecated device registry lookups

### DIFF
--- a/custom_components/ble_monitor/binary_sensor.py
+++ b/custom_components/ble_monitor/binary_sensor.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass, config_entry, add_entities):
     _LOGGER.debug("Starting binary sensor entry startup")
 
     blemonitor = hass.data[DOMAIN]["blemonitor"]
-    bleupdater = BLEupdaterBinary(blemonitor, add_entities)
+    bleupdater = BLEupdaterBinary(blemonitor, add_entities, config_entry.entry_id)
     hass.loop.create_task(bleupdater.async_run(hass))
     _LOGGER.debug("Binary sensor entry setup finished")
     # Return successful setup
@@ -69,12 +69,13 @@ async def async_setup_entry(hass, config_entry, add_entities):
 class BLEupdaterBinary:
     """BLE monitor entities updater."""
 
-    def __init__(self, blemonitor, add_entities):
+    def __init__(self, blemonitor, add_entities, config_entry_id):
         """Initiate BLE updater."""
         _LOGGER.debug("BLE binary sensors updater initialization")
         self.monitor = blemonitor
         self.dataqueue = blemonitor.dataqueue["binary"].async_q
         self.config = blemonitor.config
+        self.config_entry_id = config_entry_id
         self.period = self.config[CONF_PERIOD]
         self.add_entities = add_entities
         _LOGGER.debug("BLE binary sensors updater initialized")
@@ -137,7 +138,9 @@ class BLEupdaterBinary:
             for device in self.config[CONF_DEVICES]:
                 # get device_model and firmware from device registry to setup binary sensor
                 key = dict_get_or(device)
-                dev = dev_registry.async_get_device({(DOMAIN, key.upper())}, set())
+                dev = dev_registry.async_get_device_by_identifier(
+                    (DOMAIN, key.upper()), self.config_entry_id
+                )
                 auto_sensors = set()
                 if dev:
                     key = identifier_clean(key)

--- a/custom_components/ble_monitor/config_flow.py
+++ b/custom_components/ble_monitor/config_flow.py
@@ -282,7 +282,9 @@ class BLEMonitorFlow(FlowHandler):
 
                 conf_key = dict_get_key_or(self._sel_device)
                 key = dict_get_or(self._sel_device).upper()
-                device = devreg.async_get_device({(DOMAIN, key)}, set())
+                device = devreg.async_get_device_by_identifier(
+                    (DOMAIN, key), self.config_entry.entry_id
+                )
                 if device is None:
                     errors[conf_key] = "cannot_delete_device"
                 else:

--- a/custom_components/ble_monitor/device_tracker.py
+++ b/custom_components/ble_monitor/device_tracker.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, config_entry, add_entities):
     _LOGGER.debug("Starting device tracker entry startup")
 
     blemonitor = hass.data[DOMAIN]["blemonitor"]
-    bleupdater = BLEupdaterTracker(blemonitor, add_entities)
+    bleupdater = BLEupdaterTracker(blemonitor, add_entities, config_entry.entry_id)
     hass.loop.create_task(bleupdater.async_run(hass))
     _LOGGER.debug("Device Tracker entry setup finished")
     # Return successful setup
@@ -55,12 +55,13 @@ async def async_setup_entry(hass, config_entry, add_entities):
 class BLEupdaterTracker:
     """BLE monitor entities updater."""
 
-    def __init__(self, blemonitor, add_entities):
+    def __init__(self, blemonitor, add_entities, config_entry_id):
         """Initiate BLE updater."""
         _LOGGER.debug("BLE device tracker updater initialization")
         self.monitor = blemonitor
         self.dataqueue = blemonitor.dataqueue["tracker"].async_q
         self.config = blemonitor.config
+        self.config_entry_id = config_entry_id
         self.period = self.config[CONF_PERIOD]
         self.add_entities = add_entities
         _LOGGER.debug("BLE device tracker updater initialized")
@@ -95,7 +96,9 @@ class BLEupdaterTracker:
                 key = dict_get_or(device)
                 if CONF_DEVICE_TRACK in device and device[CONF_DEVICE_TRACK]:
                     # setup device trackers from device registry
-                    dev = dev_registry.async_get_device({(DOMAIN, key.upper())}, set())
+                    dev = dev_registry.async_get_device_by_identifier(
+                        (DOMAIN, key.upper()), self.config_entry_id
+                    )
                     if dev:
                         key = identifier_clean(key)
                         trackers = await async_add_device_tracker(key)

--- a/custom_components/ble_monitor/sensor.py
+++ b/custom_components/ble_monitor/sensor.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass, config_entry, add_entities):
     """Set up the measuring sensor entry."""
     _LOGGER.debug("Starting measuring sensor entry startup")
     blemonitor = hass.data[DOMAIN]["blemonitor"]
-    bleupdater = BLEupdater(blemonitor, add_entities)
+    bleupdater = BLEupdater(blemonitor, add_entities, config_entry.entry_id)
     hass.loop.create_task(bleupdater.async_run(hass))
     _LOGGER.debug("Measuring sensor entry setup finished")
     # Return successful setup
@@ -80,12 +80,13 @@ async def async_setup_entry(hass, config_entry, add_entities):
 class BLEupdater:
     """BLE monitor entities updater."""
 
-    def __init__(self, blemonitor, add_entities):
+    def __init__(self, blemonitor, add_entities, config_entry_id):
         """Initiate BLE updater."""
         _LOGGER.debug("BLE sensors updater initialization")
         self.monitor = blemonitor
         self.dataqueue = blemonitor.dataqueue["measuring"].async_q
         self.config = blemonitor.config
+        self.config_entry_id = config_entry_id
         self.period = self.config[CONF_PERIOD]
         self.add_entities = add_entities
         _LOGGER.debug("BLE sensors updater initialized")
@@ -159,7 +160,9 @@ class BLEupdater:
             for device in self.config[CONF_DEVICES]:
                 # get device_model and firmware from device registry to setup sensor
                 key = dict_get_or(device)
-                dev = dev_registry.async_get_device({(DOMAIN, key.upper())}, set())
+                dev = dev_registry.async_get_device_by_identifier(
+                    (DOMAIN, key.upper()), self.config_entry_id
+                )
                 auto_sensors = set()
                 if dev:
                     key = identifier_clean(key)

--- a/custom_components/ble_monitor/test/test_device_registry.py
+++ b/custom_components/ble_monitor/test/test_device_registry.py
@@ -1,0 +1,51 @@
+"""Tests for BLE Monitor device registry lookups."""
+
+from unittest.mock import Mock
+
+from homeassistant.helpers import device_registry as dr
+
+from ble_monitor.const import DOMAIN
+
+
+def test_identifier_lookup_is_scoped_to_config_entry():
+    """An identifier lookup selects only the BLE Monitor entry's device."""
+    hass = Mock()
+    hass.config_entries.async_get_entry.return_value = Mock(domain=DOMAIN)
+    registry = object.__new__(dr.DeviceRegistry)
+    registry.hass = hass
+    registry.devices = dr.ActiveDeviceRegistryItems()
+    registry.deleted_devices = dr.DeletedDeviceRegistryItems()
+    registry.async_schedule_save = Mock()
+
+    ble_entry_id = "ble-monitor-entry"
+    other_entry_id = "other-entry"
+    identifier = (DOMAIN, "A4C138000001")
+    ble_device = dr.DeviceEntry(
+        config_entry_id=ble_entry_id,
+        identifiers={identifier},
+        name="BLE Monitor device",
+    )
+    other_device = dr.DeviceEntry(
+        config_entry_id=other_entry_id,
+        identifiers={identifier},
+        name="Other config entry device",
+    )
+    registry.devices[ble_device.id] = ble_device
+    registry.devices[other_device.id] = other_device
+
+    selected = registry.async_get_device_by_identifier(
+        identifier, ble_entry_id
+    )
+
+    assert selected == ble_device
+    assert selected != other_device
+
+    registry.async_remove_device(selected.id)
+
+    assert registry.async_get_device_by_identifier(
+        identifier, ble_entry_id
+    ) is None
+    assert registry.async_get_device_by_identifier(
+        identifier, other_entry_id
+    ) == other_device
+    hass.bus.async_fire_internal.assert_called_once()

--- a/custom_components/ble_monitor/test/test_device_registry.py
+++ b/custom_components/ble_monitor/test/test_device_registry.py
@@ -2,9 +2,8 @@
 
 from unittest.mock import Mock
 
-from homeassistant.helpers import device_registry as dr
-
 from ble_monitor.const import DOMAIN
+from homeassistant.helpers import device_registry as dr
 
 
 def test_identifier_lookup_is_scoped_to_config_entry():

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Passive BLE monitor integration",
-  "homeassistant": "2026.7.0"
+  "homeassistant": "2026.8.0"
 }


### PR DESCRIPTION
## Summary

Migrate BLE Monitor away from the deprecated Home Assistant
`DeviceRegistry.async_get_device()` API.

## Problem

Home Assistant no longer treats device identifiers and connections as globally unique
across config entries.

BLE Monitor still used `async_get_device()` in its sensor, binary sensor, device tracker,
and options-flow device-registry lookups. Home Assistant now warns that this API is
deprecated and will be removed in Home Assistant 2027.8.

## Fix

Replace the four deprecated global lookups with
`async_get_device_by_identifier()` and scope each lookup to the owning BLE Monitor
config entry.

The sensor, binary sensor, and device tracker updaters now receive the config entry ID
from their platform setup, while the options flow uses its existing config entry.

This preserves the existing device identifiers and registry behavior while ensuring
that a device with the same identifier under another config entry cannot be selected
accidentally.