### PR TITLE
Validate device type in Mocreo ST7 advertisements

### DIFF
--- a/custom_components/ble_monitor/ble_parser/mocreo.py
+++ b/custom_components/ble_monitor/ble_parser/mocreo.py
@@ -100,7 +100,8 @@ def _get_value(source, pos):
 
 def parse_mocreo(self, data: bytes, local_name: str, mac: bytes):
     """Parser for MOCREO sensors"""
-    if data[0] == 0x11 and data[1] == 0xff and data[2] == 0x4a:
+    st7_format = data[0] == 0x11 and data[1] == 0xff and data[2] == 0x4a
+    if st7_format:
         common_data = data[9:]  #Mocreo's oddball ST7 format
     else:
         common_data = data[2:] #Mocreo's "normal" format
@@ -108,6 +109,8 @@ def parse_mocreo(self, data: bytes, local_name: str, mac: bytes):
     result = {"firmware": firmware}
 
     device_type = _get_value(common_data, COMMON_DATA_PARSING_FORMAT["device_type"])
+    if st7_format and device_type != 0x10:
+        return None
     version = _get_value(common_data, COMMON_DATA_PARSING_FORMAT["version"])
     battery = _get_value(common_data, COMMON_DATA_PARSING_FORMAT["battery_percentage"])
 

--- a/custom_components/ble_monitor/test/test_mocreo_parser.py
+++ b/custom_components/ble_monitor/test/test_mocreo_parser.py
@@ -2,10 +2,37 @@
 import datetime
 
 from ble_monitor.ble_parser import BleParser
+from ble_monitor.ble_parser.mocreo import parse_mocreo
 
 
 class TestMOCREO:
     """Tests for the MOCREO parser"""
+
+    def test_MOCREO_ST7(self):
+        """Test the special MOCREO ST7 layout with a synthetic valid payload."""
+        data = bytes.fromhex("11ff4a000000000000001000006492090000")
+
+        sensor_msg = parse_mocreo(
+            None, data, "ST7", bytes.fromhex("30aea400aabb")
+        )
+
+        assert sensor_msg == {
+            "firmware": "MOCREO",
+            "temperature": 24.5,
+            "battery": 100,
+            "data": True,
+            "mac": "30AEA400AABB",
+            "type": "ST7",
+            "packet": "no packet id",
+        }
+
+    def test_MOCREO_ST7_rejects_cross_format_device_type(self):
+        """A short ST7-layout payload cannot be interpreted as an SD1 packet."""
+        data = bytes.fromhex("11ff4a000000000000009500000000000000")
+
+        assert parse_mocreo(
+            None, data, "ST7", bytes.fromhex("30aea400aabb")
+        ) is None
 
     def test_MOCREO_ST5(self):
         """Test MOCREO parser for ST5."""


### PR DESCRIPTION
## Summary

Reject malformed Mocreo ST7 advertisements whose embedded device type does not match the ST7 packet format.

## Problem

Mocreo uses different advertisement layouts for ST7 and other devices.

The special ST7 format uses a different payload offset, but a corrupted device-type byte could cause that shorter payload to be interpreted as an SD1 advertisement.

The SD1 parsing path then accessed fields that are not present in the ST7 layout, resulting in `IndexError`.