### PR TITLE
Preserve first Mi Scale measurement after startup

### DIFF
--- a/custom_components/ble_monitor/ble_parser/miscale.py
+++ b/custom_components/ble_monitor/ble_parser/miscale.py
@@ -100,6 +100,14 @@ def parse_miscale(self, data: bytes, mac: bytes):
         if self.filter_duplicates is True:
             return None
     self.lpacket_ids[mac] = packet_id
+    if (
+        prev_packet is None
+        and self.filter_duplicates is True
+        and is_stabilized
+        and weight_removed
+    ):
+        # Ignore a stale, removed measurement when the scale wakes after a restart
+        return None
 
     result.update({
         "type": device_type,

--- a/custom_components/ble_monitor/ble_parser/miscale.py
+++ b/custom_components/ble_monitor/ble_parser/miscale.py
@@ -100,10 +100,6 @@ def parse_miscale(self, data: bytes, mac: bytes):
         if self.filter_duplicates is True:
             return None
     self.lpacket_ids[mac] = packet_id
-    if prev_packet is None:
-        if self.filter_duplicates is True:
-            # ignore first message after a restart
-            return None
 
     result.update({
         "type": device_type,

--- a/custom_components/ble_monitor/test/test_miscale_parser.py
+++ b/custom_components/ble_monitor/test/test_miscale_parser.py
@@ -2,6 +2,22 @@
 from ble_monitor.ble_parser import BleParser
 
 
+# Real Mi Scale V2 advertisements from
+# https://github.com/custom-components/ble_monitor/issues/1094
+ISSUE_1094_NON_STABILIZED = bytes.fromhex(
+    "043E3502010001C81555E346F12902010603021B1810161B180204B2070103131A130000AC49"
+    "06094D4942435309FF5701F146E35515C8B0"
+)
+ISSUE_1094_STABILIZED = bytes.fromhex(
+    "043E3502010001C81555E346F12902010603021B1810161B180226B2070103131A15E601604A"
+    "06094D4942435309FF5701F146E35515C8B6"
+)
+ISSUE_1094_WEIGHT_REMOVED = bytes.fromhex(
+    "043E3502010001C81555E346F12902010603021B1810161B1802A6B2070103131A15E601604A"
+    "06094D4942435309FF5701F146E35515C8B9"
+)
+
+
 class TestMiscale:
     """Tests for the MiScale parser"""
     def test_miscale_v1(self):
@@ -105,3 +121,50 @@ class TestMiscale:
         assert sensor_msg["stabilized"] == 1
         assert sensor_msg["impedance"] == 428
         assert sensor_msg["rssi"] == -66
+
+    def test_miscale_v2_first_stabilized_packet_and_duplicate(self):
+        """Test that the first stable packet is accepted and its repeat is ignored."""
+        ble_parser = BleParser(filter_duplicates=True)
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_STABILIZED)
+        assert sensor_msg["weight"] == 95.2
+        assert sensor_msg["impedance"] == 486
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_STABILIZED)
+        assert sensor_msg is None
+
+    def test_miscale_v2_duplicate_sequence(self):
+        """Test duplicate filtering with the real sequence from issue 1094."""
+        ble_parser = BleParser(filter_duplicates=True)
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_NON_STABILIZED)
+        assert sensor_msg["non-stabilized weight"] == 94.3
+        assert "weight" not in sensor_msg
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_STABILIZED)
+        assert sensor_msg["weight"] == 95.2
+        assert sensor_msg["impedance"] == 486
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_STABILIZED)
+        assert sensor_msg is None
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_WEIGHT_REMOVED)
+        assert sensor_msg["weight removed"] == 1
+        assert "weight" not in sensor_msg
+
+    def test_miscale_v2_same_measurement_different_timestamp(self):
+        """Test that timestamps distinguish otherwise identical measurements."""
+        # Create a protocol-valid synthetic variant of the real stable packet by
+        # changing only the timestamp's seconds byte.
+        second_timestamp = bytearray(ISSUE_1094_STABILIZED)
+        service_payload = bytes.fromhex("0226B2070103131A15E601604A")
+        payload_start = ISSUE_1094_STABILIZED.index(service_payload)
+        second_timestamp[payload_start + 8] = 0x16
+
+        ble_parser = BleParser(filter_duplicates=True)
+        first_msg, _ = ble_parser.parse_raw_data(ISSUE_1094_STABILIZED)
+        second_msg, _ = ble_parser.parse_raw_data(bytes(second_timestamp))
+
+        assert first_msg["weight"] == second_msg["weight"] == 95.2
+        assert first_msg["impedance"] == second_msg["impedance"] == 486
+        assert first_msg["packet"] != second_msg["packet"]

--- a/custom_components/ble_monitor/test/test_miscale_parser.py
+++ b/custom_components/ble_monitor/test/test_miscale_parser.py
@@ -1,7 +1,6 @@
 """The tests for the Mi Scale ble_parser."""
 from ble_monitor.ble_parser import BleParser
 
-
 # Real Mi Scale V1 advertisements from
 # https://github.com/custom-components/ble_monitor/issues/366
 ISSUE_366_STALE_WEIGHT_REMOVED = bytes.fromhex(

--- a/custom_components/ble_monitor/test/test_miscale_parser.py
+++ b/custom_components/ble_monitor/test/test_miscale_parser.py
@@ -2,6 +2,17 @@
 from ble_monitor.ble_parser import BleParser
 
 
+# Real Mi Scale V1 advertisements from
+# https://github.com/custom-components/ble_monitor/issues/366
+ISSUE_366_STALE_WEIGHT_REMOVED = bytes.fromhex(
+    "043E2B020100008995C08C47C81F02010603021D1809FF5701C8478CC095890D161D18A29844"
+    "E507051B162135C6"
+)
+ISSUE_366_LIVE_NON_STABILIZED = bytes.fromhex(
+    "043E2B020100008995C08C47C81F02010603021D1809FF5701C8478CC095890D161D18024844"
+    "E507051C110C09CC"
+)
+
 # Real Mi Scale V2 advertisements from
 # https://github.com/custom-components/ble_monitor/issues/1094
 ISSUE_1094_NON_STABILIZED = bytes.fromhex(
@@ -121,6 +132,22 @@ class TestMiscale:
         assert sensor_msg["stabilized"] == 1
         assert sensor_msg["impedance"] == 428
         assert sensor_msg["rssi"] == -66
+
+    def test_miscale_v1_stale_first_packet(self):
+        """Test that the stale first packet from issue 366 remains suppressed."""
+        ble_parser = BleParser(filter_duplicates=True)
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_366_STALE_WEIGHT_REMOVED)
+        assert sensor_msg is None
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_366_STALE_WEIGHT_REMOVED)
+        assert sensor_msg is None
+
+        sensor_msg, _ = ble_parser.parse_raw_data(ISSUE_366_LIVE_NON_STABILIZED)
+        assert sensor_msg["non-stabilized weight"] == 87.4
+        assert sensor_msg["stabilized"] == 0
+        assert sensor_msg["weight removed"] == 0
+        assert "weight" not in sensor_msg
 
     def test_miscale_v2_first_stabilized_packet_and_duplicate(self):
         """Test that the first stable packet is accepted and its repeat is ignored."""


### PR DESCRIPTION
## Summary

Allow the first valid Mi Scale advertisement after BLE Monitor startup to be processed.

## Problem

Mi Scale duplicate filtering intentionally discarded the first packet received after parser initialization while still storing its packet identifier.

If BLE Monitor started or restarted while a scale was already repeatedly advertising a stable measurement, that first stable result was discarded and subsequent identical retransmissions were then filtered as duplicates.

This could cause the complete stable weight and impedance result to be missed.

The original first packet suppression was introduced to avoid restoring stale scale data after restart. The historical stale frame carried the `weight_removed` flag, which is still handled separately by the current parser.

## Fix

Remove the first packet rejection and suppress only advertisements whose packet identifier matches a previously processed packet.

Existing duplicate filtering, Mi Scale V1/V2 parsing, stabilized measurements, impedance handling, and weight removed behavior remain unchanged.