### PR TITLE
Expose no motion duration for MJYD02YL

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -13,7 +13,8 @@ from homeassistant.const import (LIGHT_LUX, PERCENTAGE,
                                  UnitOfConductivity, UnitOfDensity,
                                  UnitOfElectricPotential, UnitOfEnergy,
                                  UnitOfMass, UnitOfPower, UnitOfPressure,
-                                 UnitOfRatio, UnitOfTemperature, UnitOfVolume)
+                                 UnitOfRatio, UnitOfTemperature, UnitOfTime,
+                                 UnitOfVolume)
 from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "ble_monitor"
@@ -1358,6 +1359,18 @@ SENSOR_TYPES: tuple[BLEMonitorSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     BLEMonitorSensorEntityDescription(
+        key="no motion time",
+        sensor_class="InstantUpdateSensor",
+        update_behavior="Instantly",
+        name="no motion time",
+        unique_id="no_motion_time_",
+        icon="mdi:motion-sensor-off",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        device_class=SensorDeviceClass.DURATION,
+        suggested_display_precision=0,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    BLEMonitorSensorEntityDescription(
         key="pressure present duration",
         sensor_class="InstantUpdateSensor",
         update_behavior="Instantly",
@@ -2079,7 +2092,7 @@ MEASUREMENT_DICT = {
     'YM-K1501'                : [["rssi"], ["temperature"], ["switch"]],
     'YM-K1501EU'              : [["rssi"], ["temperature"], ["switch"]],
     'V-SK152'                 : [["rssi"], ["temperature"], ["switch"]],
-    'MJYD02YL'                : [["battery", "rssi"], [], ["light", "motion"]],
+    'MJYD02YL'                : [["battery", "rssi"], ["no motion time"], ["light", "motion"]],
     'MUE4094RT'               : [["rssi"], [], ["motion"]],
     'RTCGQ02LM'               : [["battery", "rssi"], ["button"], ["light", "motion"]],
     'MMC-T201-1'              : [["temperature", "battery", "rssi"], [], []],

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -4,9 +4,12 @@ import datetime
 from ble_monitor.ble_parser import BleParser
 from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj4e16,
                                            obj4e17, obj5a16, obj560c, obj560d,
-                                           obj560e, obj1001, obj3003, obj4810,
-                                           obj4850, obj4851, obj4852, obj5010)
+                                           obj560e, obj1001, obj1017, obj3003,
+                                           obj4810, obj4850, obj4851, obj4852,
+                                           obj5010)
 from ble_monitor.const import MEASUREMENT_DICT, SENSOR_TYPES
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfTime
 
 
 class TestXiaomi:
@@ -567,6 +570,24 @@ class TestXiaomi:
 
     def test_Xiaomi_MJYD02YL(self):
         """Test Xiaomi parser for MJYD02YL."""
+        assert obj1017(bytes.fromhex("00000000")) == {
+            "motion": 1,
+            "no motion time": 0,
+        }
+        assert obj1017(bytes.fromhex("78000000")) == {
+            "motion": 0,
+            "no motion time": 120,
+        }
+
+        assert "no motion time" in MEASUREMENT_DICT["MJYD02YL"][1]
+        assert MEASUREMENT_DICT["MJYD02YL"][2] == ["light", "motion"]
+
+        sensor_description = next(
+            sensor for sensor in SENSOR_TYPES if sensor.key == "no motion time"
+        )
+        assert sensor_description.native_unit_of_measurement == UnitOfTime.SECONDS
+        assert sensor_description.device_class == SensorDeviceClass.DURATION
+        assert sensor_description.state_class == SensorStateClass.MEASUREMENT
 
     def test_Xiaomi_MJWSD06MMC(self):
         """Test Xiaomi parser for MJWSD06MMC with encryption."""

--- a/docs/_devices/Xiaomi_MJYD02YL.md
+++ b/docs/_devices/Xiaomi_MJYD02YL.md
@@ -7,6 +7,7 @@ physical_description:
 broadcasted_properties:
   - battery
   - motion
+  - no motion time
   - light
   - rssi
 broadcasted_property_notes:
@@ -15,6 +16,7 @@ active_scan:
 encryption_key: true
 custom_firmware:
 notes:
+  - No motion time is the number of seconds since motion was last detected.
   - Light state is broadcasted once every 5 minutes when no motion is detected, when motion is detected the sensor also broadcasts the light state. Motion state is broadcasted when motion is detected, but is also broadcasted once per 5 minutes. If this message is within 30 seconds after motion, it's broadcasting `motion detected`, if it's after 30 seconds, it's broadcasting `motion clear`. Additionally, `motion clear` messages are broadcasted at 2, 5, 10, 20 and 30 minutes after the last motion.
   - You can use the [reset_timer](configuration_params#reset_timer) option if you want to use a different time to set the sensor to `motion clear`.
   - Battery is broadcasted once every 5 minutes.


### PR DESCRIPTION
## Summary

Expose the idle/no-motion duration reported by Xiaomi MJYD02YL devices as a standalone sensor.

## Problem

The Xiaomi parser already decodes object `0x1017` and reports the elapsed no-motion time in seconds.

However, MJYD02YL did not map this parsed value to a Home Assistant sensor, so the information was discarded.

## Fix

Add a standalone duration sensor for the existing no motion time value and map it to MJYD02YL.

The sensor reports the number of seconds since motion was last detected.

Existing motion, light, battery, RSSI, reset timer, and parser behavior remains unchanged.

Regression coverage verifies the known `0` and `120` second values while preserving the existing motion state behavior.