### PR TITLE
Handle invalid Oras and Garnet SeeLevel payloads

### DIFF
--- a/custom_components/ble_monitor/ble_parser/oras.py
+++ b/custom_components/ble_monitor/ble_parser/oras.py
@@ -33,15 +33,16 @@ def parse_oras(self, data: bytes, mac: bytes):
         device_type = "SeeLevel II 709-BTP3"
 
         sensor_id = data[7]
-        try:
-            sensor_type = SENSOR_TYPE[sensor_id]
-        except ValueError:
+        sensor_type = SENSOR_TYPE.get(sensor_id)
+        if sensor_type is None:
             return None
 
         try:
-            sensor_data = int(data[8:11].decode("ASCII"))
-        except ValueError:
             error_code = data[8:11].decode("ASCII")
+            sensor_data = int(error_code)
+        except UnicodeDecodeError:
+            return None
+        except ValueError:
             _LOGGER.error(
                 "Garnet SeeLevel II 709-BTP3 is reporting error %s for sensor %s",
                 error_code,
@@ -52,9 +53,12 @@ def parse_oras(self, data: bytes, mac: bytes):
         if sensor_id == 13:
             sensor_data /= 10
 
-        sensor_volume = data[11:14].decode("ASCII")
-        sensor_total = data[14:17].decode("ASCII")
-        sensor_alarm = int(chr(data[17]))
+        try:
+            sensor_volume = data[11:14].decode("ASCII")
+            sensor_total = data[14:17].decode("ASCII")
+            sensor_alarm = int(chr(data[17]))
+        except (UnicodeDecodeError, ValueError):
+            return None
 
         result.update({
             sensor_type: sensor_data,
@@ -71,6 +75,8 @@ def parse_oras(self, data: bytes, mac: bytes):
         firmware = "Oras"
         device_type = "Electra Washbasin Faucet"
         battery = data[5]
+        if battery > 100:
+            return None
         result.update({"battery": battery})
     else:
         if self.report_unknown in ["Oras", "Garnet"]:

--- a/custom_components/ble_monitor/test/test_oras.py
+++ b/custom_components/ble_monitor/test/test_oras.py
@@ -1,5 +1,12 @@
 """The tests for the Oras ble_parser."""
+import pytest
 from ble_monitor.ble_parser import BleParser
+from ble_monitor.ble_parser.oras import parse_oras
+
+GARNET_PAYLOAD = bytes.fromhex("11ff31010c464e0120373130303030303030")
+GARNET_MAC = bytes.fromhex("a4c138a5b9ad")
+ORAS_PAYLOAD = bytes.fromhex("15ff3101006400323131313030373933350020202020")
+ORAS_MAC = bytes.fromhex("a4c1380f06da")
 
 
 class TestOras:
@@ -19,6 +26,23 @@ class TestOras:
         assert sensor_msg["data"]
         assert sensor_msg["battery"] == 100
         assert sensor_msg["rssi"] == -52
+
+    def test_oras_empty_battery(self):
+        """Test Oras parser accepts an empty battery."""
+        data = bytearray(ORAS_PAYLOAD)
+        data[5] = 0
+
+        sensor_msg = parse_oras(BleParser(), bytes(data), ORAS_MAC)
+
+        assert sensor_msg["battery"] == 0
+
+    @pytest.mark.parametrize("battery", [101, 255])
+    def test_oras_invalid_battery(self, battery):
+        """Test invalid Oras battery percentages are ignored."""
+        data = bytearray(ORAS_PAYLOAD)
+        data[5] = battery
+
+        assert parse_oras(BleParser(), bytes(data), ORAS_MAC) is None
 
     def test_garnet_battery(self):
         """Test Oras parser for Garnet 709BT battery sensor."""
@@ -53,3 +77,20 @@ class TestOras:
         assert sensor_msg["black tank"] == 71
         assert sensor_msg["problem"] == 0
         assert sensor_msg["rssi"] == -52
+
+    @pytest.mark.parametrize(
+        ("index", "value"),
+        [
+            (7, 14),
+            (8, 0xFF),
+            (11, 0xFF),
+            (14, 0xFF),
+            (17, ord("X")),
+        ],
+    )
+    def test_garnet_invalid_fields(self, index, value):
+        """Test malformed Garnet fields are ignored."""
+        data = bytearray(GARNET_PAYLOAD)
+        data[index] = value
+
+        assert parse_oras(BleParser(), bytes(data), GARNET_MAC) is None


### PR DESCRIPTION
## Summary

Improve malformed payload validation for Oras faucets and Garnet SeeLevel devices.

## Problem

The shared Oras parser had several content and validation gaps.

In the Garnet SeeLevel branch, unknown sensor identifiers and malformed ASCII or numeric fields could raise parser exceptions.

In the Oras faucet branch, malformed advertisements could report impossible battery percentages above 100%.

## Fix

Handle unknown Garnet sensor identifiers safely and validate the affected ASCII and numeric fields before using them.

Also reject Oras battery values outside the valid percentage range.

Garnet device status/error codes continue to follow the existing logging behavior, while malformed packets are ignored without producing exceptions or invalid Home Assistant states.

Valid Oras and Garnet SeeLevel advertisements remain unchanged.

Regression coverage verifies existing valid packets together with malformed sensor IDs, ASCII fields, alarm values, and battery percentages.