### PR TITLE
Handle invalid Kegtron port names

### DIFF
--- a/custom_components/ble_monitor/ble_parser/kegtron.py
+++ b/custom_components/ble_monitor/ble_parser/kegtron.py
@@ -56,7 +56,7 @@ def parse_kegtron(self, data: bytes, mac: bytes):
         else:
             port_count = "Single port device"
 
-        port_name = str(port_name.decode("utf-8").rstrip('\x00'))
+        port_name = str(port_name.decode("utf-8", errors="replace").rstrip('\x00'))
 
         result = {
             "keg size": keg_size,

--- a/custom_components/ble_monitor/test/test_kegtron_parser.py
+++ b/custom_components/ble_monitor/test/test_kegtron_parser.py
@@ -26,6 +26,20 @@ class TestKegtron:
         assert sensor_msg["volume dispensed port 1"] == 0.738
         assert sensor_msg["rssi"] == -82
 
+    def test_kegtron_invalid_utf8_port_name(self):
+        """Test Kegtron parser replaces invalid UTF-8 in the port name."""
+        # Based on the KT-100 fixture, with its first port-name byte replaced by 0xFF.
+        data_string = "043e2b02010400759b5c5ecfd01f1effffff49ef138802e201ff696e676c6520506f7274000000000000000000ae"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["type"] == "Kegtron KT-100"
+        assert sensor_msg["mac"] == "D0CF5E5C9B75"
+        assert sensor_msg["port name"] == "\ufffdingle Port"
+        assert sensor_msg["volume dispensed port 1"] == 0.738
+
     def test_kegtron_kt200(self):
         """Test kegtron parser for KT-200."""
         data_string = "043e2b02010400759b5c5ecfd01f1effffff49ef138802e251326e6420506f7274000000000000000000000000af"


### PR DESCRIPTION
## Summary

Prevent malformed Kegtron port names from causing UTF-8 decoding exceptions.

## Problem

The Kegtron parser decoded the advertised port-name field using strict UTF-8.

Because this field comes directly from BLE advertisement data, an invalid byte sequence could raise `UnicodeDecodeError` and prevent an otherwise valid Kegtron measurement from being processed.

## Fix

Decode the descriptive port name field using UTF-8 replacement handling.

Invalid byte sequences are now represented with replacement characters while the remaining measurement data continues to be processed.