### PR TITLE
Handle invalid ATC encryption key lengths

### DIFF
--- a/custom_components/ble_monitor/ble_parser/atc.py
+++ b/custom_components/ble_monitor/ble_parser/atc.py
@@ -144,6 +144,7 @@ def decrypt_atc(self, data, atc_mac):
         key = self.aeskeys[atc_mac]
         if len(key) != 16:
             _LOGGER.error("Encryption key should be 16 bytes (32 characters) long")
+            return None
     except KeyError:
         # no encryption key found
         _LOGGER.error("No encryption key found for ATC device with MAC: %s", to_mac(atc_mac))

--- a/custom_components/ble_monitor/test/test_atc_parser.py
+++ b/custom_components/ble_monitor/test/test_atc_parser.py
@@ -1,5 +1,11 @@
 """The tests for the ATC ble_parser."""
+import pytest
 from ble_monitor.ble_parser import BleParser
+from ble_monitor.ble_parser.atc import decrypt_atc
+
+ATC_ENCRYPTED_DATA = bytes.fromhex("0e161a1811d603fbfa7b6dfb1e26fd")
+ATC_MAC = bytes.fromhex("a4c1388d18b2")
+ATC_KEY = bytes.fromhex("b9ea895fac7eea6d30532432a516f3a3")
 
 
 class TestATC:
@@ -148,3 +154,28 @@ class TestATC:
         assert sensor_msg["voltage"] == 2.749
         assert sensor_msg["battery"] == 61
         assert sensor_msg["rssi"] == -30
+
+    def test_decrypt_atc_valid_key(self):
+        """Test valid ATC encryption key decrypts as before."""
+        ble_parser = BleParser(aeskeys={ATC_MAC: ATC_KEY})
+
+        assert decrypt_atc(ble_parser, ATC_ENCRYPTED_DATA, ATC_MAC) == b")\tM\x10=\x04"
+
+    @pytest.mark.parametrize("key_length", [0, 12, 15, 17])
+    def test_decrypt_atc_invalid_key_length(self, key_length):
+        """Test invalid ATC encryption key lengths are rejected."""
+        ble_parser = BleParser(aeskeys={ATC_MAC: bytes(key_length)})
+
+        assert decrypt_atc(ble_parser, ATC_ENCRYPTED_DATA, ATC_MAC) is None
+
+    def test_atc_invalid_key_length(self):
+        """Test an invalid key produces no decrypted ATC measurement."""
+        data = bytes.fromhex(
+            "043e1b02010000b2188d38c1a40f0e161a1811d603fbfa7b6dfb1e26fde2"
+        )
+        ble_parser = BleParser(aeskeys={ATC_MAC: bytes(12)})
+
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["data"] is False
+        assert "temperature" not in sensor_msg


### PR DESCRIPTION
## Summary

Prevent invalid ATC encryption key lengths from raising during BLE advertisement decryption.

## Problem

BLE Monitor accepts both 24 and 32 character hexadecimal encryption keys because different supported devices use different key formats.

Encrypted ATC devices require a 16 byte key. `decrypt_atc()` already detected invalid key lengths and logged an error, but continued to `AES.new()`, which raises `ValueError` for unsupported AES key sizes.

A currently accepted 24-character hexadecimal key becomes a 12 byte key and can therefore reach this path for an ATC device.

## Fix

Return `None` immediately when an ATC encryption key is not 16 bytes long.

This preserves the existing shared encryption-key validation and legacy 24character key support for other devices while preventing invalid ATC keys from reaching AES initialization.

Valid ATC keys and existing encrypted measurement behavior remain unchanged.

Regression coverage verifies valid decryption together with invalid 12, 15, 17, and zero byte keys.