### PR TITLE
Parse Xiaomi brushing timestamps in UTC

### DIFF
--- a/custom_components/ble_monitor/ble_parser/xiaomi.py
+++ b/custom_components/ble_monitor/ble_parser/xiaomi.py
@@ -2,6 +2,7 @@
 import logging
 import math
 import struct
+from datetime import timezone
 
 from Cryptodome.Cipher import AES
 from homeassistant.util import datetime
@@ -697,12 +698,16 @@ def obj3003(xobj):
         # Start of brushing
         result["toothbrush"] = 1
         start_time = struct.unpack('<L', xobj[1:5])[0]
-        result["start time"] = datetime.fromtimestamp(start_time)
+        result["start time"] = datetime.fromtimestamp(
+            start_time, tz=timezone.utc
+        ).replace(tzinfo=None)
     elif start_obj == 1:
         # End of brushing
         result["toothbrush"] = 0
         end_time = struct.unpack('<L', xobj[1:5])[0]
-        result["end time"] = datetime.fromtimestamp(end_time)
+        result["end time"] = datetime.fromtimestamp(
+            end_time, tz=timezone.utc
+        ).replace(tzinfo=None)
 
     if len(xobj) == 6:
         result["score"] = xobj[5]

--- a/custom_components/ble_monitor/test/test_xiaomi_parser.py
+++ b/custom_components/ble_monitor/test/test_xiaomi_parser.py
@@ -1,5 +1,7 @@
 """The tests for the Xiaomi ble_parser."""
 import datetime
+import os
+import time
 
 from ble_monitor.ble_parser import BleParser
 from ble_monitor.ble_parser.xiaomi import (obj4e0c, obj4e0d, obj4e0e, obj4e16,
@@ -125,6 +127,33 @@ class TestXiaomi:
         """Test obj3003 parser does not crash on a truncated brushing payload."""
         assert obj3003(bytes.fromhex("00")) == {}
         assert obj3003(bytes.fromhex("0102030405")[:4]) == {}
+
+    def test_obj3003_timestamps_are_utc(self):
+        """Test obj3003 timestamps are stable across host timezones."""
+        original_tz = os.environ.get("TZ")
+        expected_time = datetime.datetime(2023, 6, 29, 10, 50, 43)
+
+        try:
+            for timezone_name in ("UTC", "Europe/Brussels"):
+                os.environ["TZ"] = timezone_name
+                time.tzset()
+
+                assert obj3003(bytes.fromhex("0003629d6453")) == {
+                    "toothbrush": 1,
+                    "start time": expected_time,
+                    "score": 83,
+                }
+                assert obj3003(bytes.fromhex("0103629d6453")) == {
+                    "toothbrush": 0,
+                    "end time": expected_time,
+                    "score": 83,
+                }
+        finally:
+            if original_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = original_tz
+            time.tzset()
 
     def test_obj1001_invalid_input(self):
         """obj1001: invalid length and unrecognized device_type return {} instead of None."""


### PR DESCRIPTION
## Summary

Make Xiaomi brushing timestamps independent of the host system timezone.

## Problem

The Xiaomi `obj3003` brushing handler converted Unix timestamps using `datetime.fromtimestamp()` without an explicit timezone.

As a result, the same BLE advertisement produced different naive datetime values depending on the timezone of the machine running BLE Monitor.

For example, the existing T700 fixture produced `10:50:43` under UTC but `12:50:43` under Europe/Brussels.

## Fix

Convert brushing timestamps explicitly through UTC while preserving the existing naive datetime result type.

Both brushing start and end timestamps are now deterministic regardless of the host timezone.

T700/T700i entity mappings, toothbrush state, score handling, and other Xiaomi datetime handlers remain unchanged.

Regression coverage verifies identical start and end timestamps under both UTC and Europe/Brussels.