### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,16 +15,16 @@ repos:
       - id: trailing-whitespace
       - id: debug-statements
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+    rev: 9.0.1
     hooks:
       - id: isort
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: [--ignore-words=.ignore_words.txt]


### PR DESCRIPTION
## Summary

Update the repository's pre commit hooks to their latest stable versions.

## Problem

The pinned pyupgrade v3.20.0 is incompatible with Python 3.14 and crashes during precommit execution because of a change in Python's `tokenize` module.

The isort and codespell hooks were also behind their latest stable releases.

## Fix

Update:

- pyupgrade from v3.20.0 to v3.21.2
- isort from 6.0.1 to 9.0.1
- codespell from v2.4.1 to v2.4.3